### PR TITLE
Node set time derivative bug

### DIFF
--- a/src/mechanics/nodes/NodeBase.h
+++ b/src/mechanics/nodes/NodeBase.h
@@ -123,11 +123,11 @@ public:
     //! @param rDof ... specific dof type
     //! @param rTimeDerivative ... time derivative
     //! @param rValue ... dof scalar value
-    void Set(Node::eDof rDof, int, double rValue)
+    void Set(Node::eDof rDof, int rTimeDerivative, double rValue)
     {
         Eigen::VectorXd value(1);
         value[0] = rValue;
-        Set(rDof, 0, value);
+        Set(rDof, rTimeDerivative, value);
     }
 
     //! @brief sets the dof values for a specific scalar dof

--- a/test/mechanics/nodes/CMakeLists.txt
+++ b/test/mechanics/nodes/CMakeLists.txt
@@ -2,5 +2,6 @@ add_unit_test(DofContainer)
 add_unit_test(DofVector)
 add_unit_test(DofType)
 add_unit_test(NodeSimple)
+add_unit_test(NodeBase)
 
 

--- a/test/mechanics/nodes/NodeBase.cpp
+++ b/test/mechanics/nodes/NodeBase.cpp
@@ -1,0 +1,81 @@
+#include <iostream>
+#include "BoostUnitTest.h"
+#include "mechanics/nodes/NodeBase.h"
+#include "mechanics/MechanicsEnums.h"
+
+class NodeBaseDerived : public NuTo::NodeBase
+{
+public:
+    void SetDofNumber(NuTo::Node::eDof a, int b, int c) override
+    {
+        std::cout << "Set global DofNumber" << std::endl;
+    }
+
+    int GetNumTimeDerivatives(NuTo::Node::eDof) const override
+    {
+        return 15;
+    }
+
+    bool IsDof(NuTo::Node::eDof) const override
+    {
+        return (true);
+    }
+
+    int GetNumDofs() const override
+    {
+        return 27;
+    }
+
+    int GetNum(NuTo::Node::eDof) const override
+    {
+        return 42;
+    }
+
+    int GetDof(NuTo::Node::eDof, int) const override
+    {
+        return 70;
+    }
+
+    const Eigen::VectorXd& Get(NuTo::Node::eDof, int td) const override
+    {
+        return mValues[td];
+    }
+
+    void Set(NuTo::Node::eDof, int td, const Eigen::VectorXd& val) override
+    {
+        mValues[td] = val;
+    }
+
+    std::set<NuTo::Node::eDof> GetDofTypes() const override
+    {
+        std::set<NuTo::Node::eDof> fakeResult;
+        fakeResult.insert(NuTo::Node::eDof::TEMPERATURE);
+        return fakeResult;
+    }
+
+    void Info(std::ostream& out) const override
+    {
+    }
+
+    NuTo::NodeBase* Clone() const override
+    {
+        return new NodeBaseDerived(*this);
+    }
+
+    std::vector<Eigen::VectorXd> mValues = {Eigen::Vector2d(1, 1), Eigen::Vector2d(2, 2)};
+};
+
+BOOST_AUTO_TEST_CASE(NodeBaseSetGet)
+{
+    NuTo::NodeBase& nd = *new NodeBaseDerived();
+
+    Eigen::VectorXd expected(1);
+
+    expected(0) = 1.1;
+    nd.Set(NuTo::Node::eDof::DISPLACEMENTS, expected(0));
+    BOOST_CHECK_EQUAL(nd.Get(NuTo::Node::eDof::DISPLACEMENTS), expected);
+
+    expected(0) = 1.2;
+    nd.Set(NuTo::Node::eDof::DISPLACEMENTS, 1, expected(0));
+    BOOST_CHECK_EQUAL(nd.Get(NuTo::Node::eDof::DISPLACEMENTS, 1), expected);
+}

--- a/test/mechanics/nodes/NodeBase.cpp
+++ b/test/mechanics/nodes/NodeBase.cpp
@@ -1,81 +1,24 @@
-#include <iostream>
 #include "BoostUnitTest.h"
+#include <fakeit.hpp>
 #include "mechanics/nodes/NodeBase.h"
 #include "mechanics/MechanicsEnums.h"
 
-class NodeBaseDerived : public NuTo::NodeBase
-{
-public:
-    void SetDofNumber(NuTo::Node::eDof a, int b, int c) override
-    {
-        std::cout << "Set global DofNumber" << std::endl;
-    }
-
-    int GetNumTimeDerivatives(NuTo::Node::eDof) const override
-    {
-        return 15;
-    }
-
-    bool IsDof(NuTo::Node::eDof) const override
-    {
-        return (true);
-    }
-
-    int GetNumDofs() const override
-    {
-        return 27;
-    }
-
-    int GetNum(NuTo::Node::eDof) const override
-    {
-        return 42;
-    }
-
-    int GetDof(NuTo::Node::eDof, int) const override
-    {
-        return 70;
-    }
-
-    const Eigen::VectorXd& Get(NuTo::Node::eDof, int td) const override
-    {
-        return mValues[td];
-    }
-
-    void Set(NuTo::Node::eDof, int td, const Eigen::VectorXd& val) override
-    {
-        mValues[td] = val;
-    }
-
-    std::set<NuTo::Node::eDof> GetDofTypes() const override
-    {
-        std::set<NuTo::Node::eDof> fakeResult;
-        fakeResult.insert(NuTo::Node::eDof::TEMPERATURE);
-        return fakeResult;
-    }
-
-    void Info(std::ostream& out) const override
-    {
-    }
-
-    NuTo::NodeBase* Clone() const override
-    {
-        return new NodeBaseDerived(*this);
-    }
-
-    std::vector<Eigen::VectorXd> mValues = {Eigen::Vector2d(1, 1), Eigen::Vector2d(2, 2)};
-};
+using namespace NuTo;
+using namespace fakeit;
 
 BOOST_AUTO_TEST_CASE(NodeBaseSetGet)
 {
-    NuTo::NodeBase& nd = *new NodeBaseDerived();
+    fakeit::Mock<NodeBase> mockNode;
+    NuTo::NodeBase& nd = mockNode.get();
+    When(OverloadedMethod(mockNode, Set, void(Node::eDof, int, const Eigen::VectorXd&))).AlwaysReturn();
 
-    Eigen::VectorXd expected(1);
+    nd.Set(NuTo::Node::eDof::DISPLACEMENTS, 2.7);
+    Verify(OverloadedMethod(mockNode, Set, void(Node::eDof, int, const Eigen::VectorXd&))
+                   .Matching([](auto, auto timeDerivative, const auto&) { return timeDerivative == 0; }))
+            .Once();
 
-    expected(0) = 1.1;
-    nd.Set(NuTo::Node::eDof::DISPLACEMENTS, expected(0));
-    BOOST_CHECK_EQUAL(nd.Get(NuTo::Node::eDof::DISPLACEMENTS), expected);
-
-    expected(0) = 1.2;
-    nd.Set(NuTo::Node::eDof::DISPLACEMENTS, 1, expected(0));
-    BOOST_CHECK_EQUAL(nd.Get(NuTo::Node::eDof::DISPLACEMENTS, 1), expected);
+    nd.Set(NuTo::Node::eDof::DISPLACEMENTS, 1, 5.6);
+    Verify(OverloadedMethod(mockNode, Set, void(Node::eDof, int, const Eigen::VectorXd&))
+                   .Matching([](auto, auto timeDerivative, const auto&) { return timeDerivative == 1; }))
+            .Once();
 }


### PR DESCRIPTION
Bug: Set method in NodeBase that uses the time derivative set everything to time derivative 0 regardless of rTimeDerivative parameter. This is fixed now but since there are some integrationtests that use this method (e.g. moisture transport) I thought (phuschke pushed me) a pull request would be appropriate to make this problem known.