### PR TITLE
PDE: Linear elastic law

### DIFF
--- a/src/mechanics/cell/Integrand.h
+++ b/src/mechanics/cell/Integrand.h
@@ -1,6 +1,4 @@
 #pragma once
-#include <memory>
-#include <boost/noncopyable.hpp>
 #include "mechanics/cell/CellData.h"
 #include "mechanics/cell/CellIPData.h"
 #include "mechanics/nodes/DofVector.h"

--- a/src/mechanics/cell/IntegrandLinearElastic.h
+++ b/src/mechanics/cell/IntegrandLinearElastic.h
@@ -1,53 +1,17 @@
 #pragma once
 
 #include "mechanics/cell/Integrand.h"
+#include "mechanics/constitutive/laws/LinearElastic.h"
 
 namespace NuTo
 {
 
 
-class LinearElasticLaw2D
-{
-public:
-    LinearElasticLaw2D(double rE, double rNu)
-        : mE(rE)
-        , mNu(rNu)
-    {
-        double factor = mE / (1.0 - (mNu * mNu));
-        double C11 = factor;
-        double C12 = factor * mNu;
-        double C33 = factor * 0.5 * (1.0 - mNu);
-
-        mC = Eigen::Matrix3d::Zero();
-        mC(0, 0) = C11;
-        mC(1, 0) = C12;
-
-        mC(0, 1) = C12;
-        mC(1, 1) = C11;
-
-        mC(2, 2) = C33;
-    }
-
-    Eigen::Vector3d Stress(Eigen::Vector3d rStrain) const
-    {
-        return mC * rStrain;
-    }
-
-    const Eigen::Matrix3d& C() const
-    {
-        return mC;
-    }
-
-    double mE;
-    double mNu;
-    Eigen::Matrix3d mC;
-};
-
 template <int TDim>
 class IntegrandLinearElastic : public NuTo::Integrand<TDim>
 {
 public:
-    IntegrandLinearElastic(const NuTo::DofType& rDofType, const LinearElasticLaw2D& rLaw)
+    IntegrandLinearElastic(const NuTo::DofType& rDofType, const Laws::LinearElastic<TDim>& rLaw)
         : mDofType(rDofType)
         , mLaw(rLaw)
     {
@@ -88,7 +52,7 @@ public:
 
 private:
     const NuTo::DofType& mDofType;
-    const LinearElasticLaw2D& mLaw;
+    const Laws::LinearElastic<TDim>& mLaw;
 };
 
 } /* NuTo */

--- a/src/mechanics/constitutive/EngineeringStrainInvariants.h
+++ b/src/mechanics/constitutive/EngineeringStrainInvariants.h
@@ -29,14 +29,14 @@ Tensor ToTensor(EngineeringStrainPDE<3>& v)
 
 //! @brief returns I1 - the first strain invariant of the characteristic equation
 //! \f[ \lambda^3 - I_1 \lambda^2 + I_2 \lambda - I_3  \f]
-double InvariantI1(const EngineeringStrainPDE<3>& v)
+double I1(const EngineeringStrainPDE<3>& v)
 {
     return v.segment<3>(0).sum();
 }
 
 //! @brief returns I2 - the first strain invariant of the characteristic equation
 //! \f[ \lambda^3 - I_1 \lambda^2 + I_2 \lambda - I_3  \f]
-double InvariantI2(const EngineeringStrainPDE<3>& v)
+double I2(const EngineeringStrainPDE<3>& v)
 {
     // e_xx = v[0]     || e_yy = v[1]     || e_zz = v[2]
     // e_yz = v[3] / 2 || e_zx = v[4] / 2 || e_xy = v[5] / 2
@@ -45,7 +45,7 @@ double InvariantI2(const EngineeringStrainPDE<3>& v)
 
 //! @brief returns I3 - the first strain invariant of the characteristic equation
 //! \f[ \lambda^3 - I_1 \lambda^2 + I_2 \lambda - I_3  \f]
-double InvariantI3(const EngineeringStrainPDE<3>& v)
+double I3(const EngineeringStrainPDE<3>& v)
 {
     // e_xx = v[0]     || e_yy = v[1]     || e_zz = v[2]
     // e_yz = v[3] / 2 || e_zx = v[4] / 2 || e_xy = v[5] / 2
@@ -56,7 +56,7 @@ double InvariantI3(const EngineeringStrainPDE<3>& v)
 //! @brief returns J2 - the second deviatoric strain invariant of the characteristic equation
 //! \f[ \lambda^3 - J_1 \lambda^2 - J_2 \lambda - J_3  \f] Note the minus sign in front of J2. This is not
 //! consistent with the I2 invariant but apparently common practice.
-double InvariantJ2(const EngineeringStrainPDE<3>& v)
+double J2(const EngineeringStrainPDE<3>& v)
 {
     const double eps_xx = v[0];
     const double eps_yy = v[1];
@@ -74,7 +74,7 @@ double InvariantJ2(const EngineeringStrainPDE<3>& v)
 //! @brief returns the deviatoric part
 EngineeringStrainPDE<3> Deviatoric(EngineeringStrainPDE<3> v)
 {
-    double I1_3 = InvariantI1(v) / 3.;
+    double I1_3 = I1(v) / 3.;
     v[0] -= I1_3;
     v[1] -= I1_3;
     v[2] -= I1_3;

--- a/src/mechanics/constitutive/EngineeringStrainInvariants.h
+++ b/src/mechanics/constitutive/EngineeringStrainInvariants.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <eigen3/Eigen/Core>
+#include "mechanics/constitutive/EngineeringStrainPDE.h"
+
+namespace NuTo
+{
+namespace EngineeringStrainInvariants
+{
+using Tensor = Eigen::Matrix3d;
+
+Tensor ToTensor(EngineeringStrainPDE<3>& v)
+{
+    Tensor t = Tensor::Zero();
+    t(0, 0) = v[0];
+    t(1, 1) = v[1];
+    t(2, 2) = v[2];
+
+    t(1, 0) = 0.5 * v[5];
+    t(0, 1) = 0.5 * v[5];
+
+    t(2, 0) = 0.5 * v[4];
+    t(0, 2) = 0.5 * v[4];
+
+    t(2, 1) = 0.5 * v[3];
+    t(1, 2) = 0.5 * v[3];
+    return t;
+}
+
+//! @brief returns I1 - the first strain invariant of the characteristic equation
+//! \f[ \lambda^3 - I_1 \lambda^2 + I_2 \lambda - I_3  \f]
+double InvariantI1(const EngineeringStrainPDE<3>& v)
+{
+    return v.segment<3>(0).sum();
+}
+
+//! @brief returns I2 - the first strain invariant of the characteristic equation
+//! \f[ \lambda^3 - I_1 \lambda^2 + I_2 \lambda - I_3  \f]
+double InvariantI2(const EngineeringStrainPDE<3>& v)
+{
+    // e_xx = v[0]     || e_yy = v[1]     || e_zz = v[2]
+    // e_yz = v[3] / 2 || e_zx = v[4] / 2 || e_xy = v[5] / 2
+    return v[0] * v[1] + v[1] * v[2] + v[2] * v[0] - 0.25 * (v[3] * v[3] + v[4] * v[4] + v[5] * v[5]);
+}
+
+//! @brief returns I3 - the first strain invariant of the characteristic equation
+//! \f[ \lambda^3 - I_1 \lambda^2 + I_2 \lambda - I_3  \f]
+double InvariantI3(const EngineeringStrainPDE<3>& v)
+{
+    // e_xx = v[0]     || e_yy = v[1]     || e_zz = v[2]
+    // e_yz = v[3] / 2 || e_zx = v[4] / 2 || e_xy = v[5] / 2
+    return v[0] * v[1] * v[2] + 0.25 * v[3] * v[4] * v[5] -
+           .25 * (v[5] * v[5] * v[2] + v[3] * v[3] * v[0] + v[4] * v[4] * v[1]);
+}
+
+//! @brief returns J2 - the second deviatoric strain invariant of the characteristic equation
+//! \f[ \lambda^3 - J_1 \lambda^2 - J_2 \lambda - J_3  \f] Note the minus sign in front of J2. This is not
+//! consistent with the I2 invariant but apparently common practice.
+double InvariantJ2(const EngineeringStrainPDE<3>& v)
+{
+    const double eps_xx = v[0];
+    const double eps_yy = v[1];
+    const double eps_zz = v[2];
+    const double eps_yz = .5 * v[3];
+    const double eps_zx = .5 * v[4];
+    const double eps_xy = .5 * v[5];
+
+    return 1. / 6. * ((eps_xx - eps_yy) * (eps_xx - eps_yy) + (eps_yy - eps_zz) * (eps_yy - eps_zz) +
+                      (eps_zz - eps_xx) * (eps_zz - eps_xx)) +
+           eps_xy * eps_xy + eps_yz * eps_yz + eps_zx * eps_zx;
+}
+
+
+//! @brief returns the deviatoric part
+EngineeringStrainPDE<3> Deviatoric(EngineeringStrainPDE<3> v)
+{
+    double I1_3 = InvariantI1(v) / 3.;
+    v[0] -= I1_3;
+    v[1] -= I1_3;
+    v[2] -= I1_3;
+    return v;
+}
+
+} /* TensorCalc */
+} /* NuTo */

--- a/src/mechanics/constitutive/EngineeringStrainPDE.h
+++ b/src/mechanics/constitutive/EngineeringStrainPDE.h
@@ -36,21 +36,21 @@ class EngineeringStrainPDE : public Eigen::Matrix<double, Voigt::Dim(TDim), 1>
 public:
     EngineeringStrainPDE() = default;
 
-    // This constructor allows you to construct EngineeringStrainPDE from Eigen expressions
+    //! @brief This constructor allows you to construct EngineeringStrainPDE from Eigen expressions
     template <typename OtherDerived>
     EngineeringStrainPDE(const Eigen::MatrixBase<OtherDerived>& other)
         : Parent(other) 
     {
     }
     
-    // This constructor allows you to construct EngineeringStrainPDE from Eigen expressions
+    //! @brief This constructor allows you to construct EngineeringStrainPDE from Eigen expressions
     template <typename OtherDerived>
     EngineeringStrainPDE(Eigen::MatrixBase<OtherDerived>&& other)
         : Parent(other) 
     {
     }
     
-    // This method allows you to assign Eigen expressions to EngineeringStrainPDE
+    //! @brief This method allows you to assign Eigen expressions to EngineeringStrainPDE
     template <typename OtherDerived>
     EngineeringStrainPDE& operator=(const Eigen::MatrixBase<OtherDerived>& other)
     {
@@ -58,7 +58,7 @@ public:
         return *this;
     }
     
-    // This method allows you to assign Eigen expressions to EngineeringStrainPDE
+    //! @brief This method allows you to assign Eigen expressions to EngineeringStrainPDE
     template <typename OtherDerived>
     EngineeringStrainPDE& operator=(Eigen::MatrixBase<OtherDerived>&& other)
     {

--- a/src/mechanics/constitutive/EngineeringStrainPDE.h
+++ b/src/mechanics/constitutive/EngineeringStrainPDE.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <eigen3/Eigen/Core>
+#include "mechanics/constitutive/Voigt.h"
+
+namespace NuTo
+{
+
+//! @brief ... Engineering strain
+/*!
+ *  Due to the symmetry of the second order engineering strain tensor the engineering strain components can be stored as
+ * vector
+ *  \f[
+ *       \boldsymbol{\varepsilon} = \begin{bmatrix}
+ *         \varepsilon_{xx}\\
+ *         \varepsilon_{yy}\\
+ *         \varepsilon_{zz}\\
+ *         2 \varepsilon_{xy}\\
+ *         2 \varepsilon_{yz}\\
+ *         2 \varepsilon_{zx}
+ *       \end{bmatrix} = \begin{bmatrix}
+ *         \varepsilon_{x}\\
+ *         \varepsilon_{y}\\
+ *         \varepsilon_{z}\\
+ *         \gamma_{xy} \\
+ *         \gamma_{yz} \\
+ *         \gamma_{zx}
+ *       \end{bmatrix}.
+ *  \f]
+ *
+ */
+template <int TDim>
+class EngineeringStrainPDE : public Eigen::Matrix<double, Voigt::Dim(TDim), 1>
+{
+    using Parent = Eigen::Matrix<double, Voigt::Dim(TDim), 1>;
+public:
+    EngineeringStrainPDE() = default;
+
+    // This constructor allows you to construct EngineeringStrainPDE from Eigen expressions
+    template <typename OtherDerived>
+    EngineeringStrainPDE(const Eigen::MatrixBase<OtherDerived>& other)
+        : Parent(other) 
+    {
+    }
+    
+    // This constructor allows you to construct EngineeringStrainPDE from Eigen expressions
+    template <typename OtherDerived>
+    EngineeringStrainPDE(Eigen::MatrixBase<OtherDerived>&& other)
+        : Parent(other) 
+    {
+    }
+    
+    // This method allows you to assign Eigen expressions to EngineeringStrainPDE
+    template <typename OtherDerived>
+    EngineeringStrainPDE& operator=(const Eigen::MatrixBase<OtherDerived>& other)
+    {
+        this->Parent::operator=(other);
+        return *this;
+    }
+    
+    // This method allows you to assign Eigen expressions to EngineeringStrainPDE
+    template <typename OtherDerived>
+    EngineeringStrainPDE& operator=(Eigen::MatrixBase<OtherDerived>&& other)
+    {
+        this->Parent::operator=(other);
+        return *this;
+    }
+};
+} /* namespace NuTo */

--- a/src/mechanics/constitutive/EngineeringStressPDE.h
+++ b/src/mechanics/constitutive/EngineeringStressPDE.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <eigen3/Eigen/Core>
+#include "mechanics/constitutive/Voigt.h"
+
+namespace NuTo
+{
+//! @brief ... Engineering stress
+/*!
+ *  3D case:
+ *  \f[
+ *     \boldsymbol{\sigma} = \begin{bmatrix}
+ *        \sigma_{x}\\
+ *        \sigma_{y}\\
+ *        \sigma_{z}\\
+ *        \tau_{yz}\\
+ *        \tau_{zx}\\
+ *        \tau_{xy}
+ *    \end{bmatrix} = \begin{bmatrix}
+ *        \sigma_{xx}\\
+ *        \sigma_{yy}\\
+ *        \sigma_{zz}\\
+ *        \sigma_{yz}\\
+ *        \sigma_{zx}\\
+ *        \sigma_{xy}
+ *    \end{bmatrix}.
+ *  \f]
+ */
+template <int TDim>
+class EngineeringStressPDE : public Eigen::Matrix<double, Voigt::Dim(TDim), 1>
+{
+    using Parent = Eigen::Matrix<double, Voigt::Dim(TDim), 1>;
+public:
+    EngineeringStressPDE() = default;
+
+    // This constructor allows you to construct EngineeringStressPDE from Eigen expressions
+    template <typename OtherDerived>
+    EngineeringStressPDE(const Eigen::MatrixBase<OtherDerived>& other)
+        : Parent(other) 
+    {
+    }
+    
+    // This constructor allows you to construct EngineeringStressPDE from Eigen expressions
+    template <typename OtherDerived>
+    EngineeringStressPDE(Eigen::MatrixBase<OtherDerived>&& other)
+        : Parent(other) 
+    {
+    }
+    
+    // This method allows you to assign Eigen expressions to EngineeringStressPDE
+    template <typename OtherDerived>
+    EngineeringStressPDE& operator=(const Eigen::MatrixBase<OtherDerived>& other)
+    {
+        this->Parent::operator=(other);
+        return *this;
+    }
+    
+    // This method allows you to assign Eigen expressions to EngineeringStressPDE
+    template <typename OtherDerived>
+    EngineeringStressPDE& operator=(Eigen::MatrixBase<OtherDerived>&& other)
+    {
+        this->Parent::operator=(other);
+        return *this;
+    }
+};
+} /* namespace NuTo */

--- a/src/mechanics/constitutive/EngineeringStressPDE.h
+++ b/src/mechanics/constitutive/EngineeringStressPDE.h
@@ -33,21 +33,21 @@ class EngineeringStressPDE : public Eigen::Matrix<double, Voigt::Dim(TDim), 1>
 public:
     EngineeringStressPDE() = default;
 
-    // This constructor allows you to construct EngineeringStressPDE from Eigen expressions
+    //! @brief This constructor allows you to construct EngineeringStressPDE from Eigen expressions
     template <typename OtherDerived>
     EngineeringStressPDE(const Eigen::MatrixBase<OtherDerived>& other)
         : Parent(other) 
     {
     }
     
-    // This constructor allows you to construct EngineeringStressPDE from Eigen expressions
+    //! @brief This constructor allows you to construct EngineeringStressPDE from Eigen expressions
     template <typename OtherDerived>
     EngineeringStressPDE(Eigen::MatrixBase<OtherDerived>&& other)
         : Parent(other) 
     {
     }
     
-    // This method allows you to assign Eigen expressions to EngineeringStressPDE
+    //! @brief This method allows you to assign Eigen expressions to EngineeringStressPDE
     template <typename OtherDerived>
     EngineeringStressPDE& operator=(const Eigen::MatrixBase<OtherDerived>& other)
     {
@@ -55,7 +55,7 @@ public:
         return *this;
     }
     
-    // This method allows you to assign Eigen expressions to EngineeringStressPDE
+    //! @brief This method allows you to assign Eigen expressions to EngineeringStressPDE
     template <typename OtherDerived>
     EngineeringStressPDE& operator=(Eigen::MatrixBase<OtherDerived>&& other)
     {

--- a/src/mechanics/constitutive/Voigt.h
+++ b/src/mechanics/constitutive/Voigt.h
@@ -1,0 +1,11 @@
+#pragma once
+namespace NuTo
+{
+struct Voigt
+{
+    static constexpr int Dim(int d)
+    {
+        return d == 1 ? 1 : (d == 2 ? 3 : 6);
+    }
+};
+} /* NuTo */

--- a/src/mechanics/constitutive/inputoutput/ConstitutivePlaneState.h
+++ b/src/mechanics/constitutive/inputoutput/ConstitutivePlaneState.h
@@ -1,15 +1,10 @@
 #pragma once
 
 #include "mechanics/constitutive/inputoutput/ConstitutiveIOBase.h"
+#include "mechanics/constitutive/inputoutput/ConstitutivePlaneStateEnum.h"
 
 namespace NuTo
 {
-
-enum class ePlaneState
-{
-    PLANE_STRESS,
-    PLANE_STRAIN
-};
 
 //! @brief Input to tell the law whether the material is under plane stress or plane strain.
 class ConstitutivePlaneState : public ConstitutiveIOBase

--- a/src/mechanics/constitutive/inputoutput/ConstitutivePlaneStateEnum.h
+++ b/src/mechanics/constitutive/inputoutput/ConstitutivePlaneStateEnum.h
@@ -1,0 +1,9 @@
+#pragma once
+namespace NuTo
+{
+enum class ePlaneState
+{
+    PLANE_STRESS,
+    PLANE_STRAIN
+};
+} /* NuTo */ 

--- a/src/mechanics/constitutive/inputoutput/EngineeringStress.h
+++ b/src/mechanics/constitutive/inputoutput/EngineeringStress.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "mechanics/constitutive/inputoutput/ConstitutiveVector.h"
-#include "mechanics/constitutive/inputoutput/ConstitutivePlaneState.h"
+#include "mechanics/constitutive/inputoutput/ConstitutivePlaneStateEnum.h"
 
 
 namespace NuTo

--- a/src/mechanics/constitutive/inputoutput/EquivalentStrain.h
+++ b/src/mechanics/constitutive/inputoutput/EquivalentStrain.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "mechanics/constitutive/inputoutput/ConstitutivePlaneState.h"
+#include "mechanics/constitutive/inputoutput/ConstitutivePlaneStateEnum.h"
 #include "mechanics/constitutive/inputoutput/EngineeringStrain.h"
 namespace NuTo
 {

--- a/src/mechanics/constitutive/laws/LinearElastic.h
+++ b/src/mechanics/constitutive/laws/LinearElastic.h
@@ -1,0 +1,134 @@
+#pragma once
+#include <type_traits>
+#include <tuple>
+#include <eigen3/Eigen/Core>
+#include "mechanics/constitutive/EngineeringStrainPDE.h"
+#include "mechanics/constitutive/EngineeringStressPDE.h"
+#include "mechanics/constitutive/inputoutput/ConstitutivePlaneStateEnum.h"
+
+namespace NuTo
+{
+namespace Laws
+{
+
+
+
+template <int TDim>
+class LinearElastic
+{
+public:
+    using ElasticTangent = Eigen::Matrix<double, Voigt::Dim(TDim), Voigt::Dim(TDim)>;
+
+    template <int U = TDim, typename std::enable_if<U != 2, int>::type = 0>
+    LinearElastic(double E, double Nu)
+        : mE(E)
+        , mNu(Nu)
+        , mC(CalculateC(E, Nu))
+    {
+    }
+
+    template <int U = TDim, typename std::enable_if<U == 2, int>::type = 0>
+    LinearElastic(double E, double Nu, ePlaneState planeState)
+        : mE(E)
+        , mNu(Nu)
+        , mC(CalculateC(E, Nu, planeState))
+    {
+    }
+
+    EngineeringStressPDE<TDim> Stress(EngineeringStrainPDE<TDim> strain) const
+    {
+        return mC * strain;
+    }
+
+    const ElasticTangent& Tangent(EngineeringStrainPDE<TDim>) const
+    {
+        return mC;
+    }
+
+private:
+    double mE;
+    double mNu;
+    ElasticTangent mC;
+
+    static ElasticTangent CalculateC(double E, double Nu, ePlaneState planeState = ePlaneState::PLANE_STRESS);
+};
+
+//! @brief calculate coefficients of the PLANE_STRESS 2D material matrix
+//! @param E ... Young's modulus
+//! @param Nu ... Poisson's ratio
+//! @return tuple <C11, C12, C33>
+std::tuple<double, double, double> CalculateCoefficients2DPlaneStress(double E, double Nu)
+{
+    double factor = E / (1.0 - (Nu * Nu));
+    return std::make_tuple(factor, // C11
+                           factor * Nu, // C12
+                           factor * 0.5 * (1.0 - Nu)); // C33
+}
+
+//! @brief calculate coefficients of the 3D material matrix
+//! @param E ... Young's modulus
+//! @param Nu ... Poisson's ratio
+//! @return tuple <C11, C12, C33>
+std::tuple<double, double, double> CalculateCoefficients3D(double E, double Nu)
+{
+    double factor = E / ((1.0 + Nu) * (1.0 - 2.0 * Nu));
+    return std::make_tuple(factor * (1.0 - Nu), // C11
+                           factor * Nu, // C12
+                           E / (2. * (1.0 + Nu))); // C33
+}
+
+template <>
+LinearElastic<1>::ElasticTangent LinearElastic<1>::CalculateC(double E, double Nu, ePlaneState)
+{
+    return ElasticTangent::Constant(E);
+}
+
+template <>
+LinearElastic<2>::ElasticTangent LinearElastic<2>::CalculateC(double E, double Nu, ePlaneState planeState)
+{
+    double C11 = 0, C12 = 0, C33 = 0;
+    if (planeState == ePlaneState::PLANE_STRESS)
+        std::tie(C11, C12, C33) = CalculateCoefficients2DPlaneStress(E, Nu);
+    else
+        std::tie(C11, C12, C33) = CalculateCoefficients3D(E, Nu);
+
+    ElasticTangent C = ElasticTangent::Zero();
+    C = Eigen::Matrix3d::Zero();
+    C(0, 0) = C11;
+    C(1, 0) = C12;
+
+    C(0, 1) = C12;
+    C(1, 1) = C11;
+
+    C(2, 2) = C33;
+    return C;
+}
+
+template <>
+LinearElastic<3>::ElasticTangent LinearElastic<3>::CalculateC(double E, double Nu, ePlaneState)
+{
+    double C11 = 0, C12 = 0, C44 = 0;
+    std::tie(C11, C12, C44) = CalculateCoefficients3D(E, Nu);
+    ElasticTangent C = ElasticTangent::Zero();
+    // C11 diagonal:
+    C(0, 0) = C11;
+    C(1, 1) = C11;
+    C(2, 2) = C11;
+
+    // C12 off diagonals:
+    C(0, 1) = C12;
+    C(0, 2) = C12;
+    C(1, 0) = C12;
+    C(1, 2) = C12;
+    C(2, 0) = C12;
+    C(2, 1) = C12;
+
+    // C44 diagonal:
+    C(3, 3) = C44;
+    C(4, 4) = C44;
+    C(5, 5) = C44;
+    return C;
+}
+
+} /* Laws */
+} /* NuTo */

--- a/src/mechanics/nodes/DofMatrixContainer.h
+++ b/src/mechanics/nodes/DofMatrixContainer.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <map>
+#include <eigen3/Eigen/Core>
+#include "mechanics/nodes/DofType.h"
+
+namespace NuTo
+{
+
+//! @brief dof container that is also capable of performing calculations.
+template <typename T>
+class DofMatrixContainer
+{
+public:
+    DofMatrixContainer& operator+=(const DofMatrixContainer& rhs)
+    {
+        for (const auto& it : rhs.mData)
+        {
+            auto& thisData = mData[it.first];
+            if (thisData.size() == 0)
+                thisData = it.second;
+            else
+                thisData += it.second;
+        }
+        return *this;
+    }
+
+    DofMatrixContainer& operator*=(double scalar)
+    {
+        for (auto& it : mData)
+            it.second *= scalar;
+        return *this;
+    }
+
+    T& operator()(const DofType& d0, const DofType& d1)
+    {
+        return mData[CantorParingFunction(d0.GetId(), d1.GetId())];
+    }
+
+    const T& operator()(const DofType& d0, const DofType& d1) const
+    {
+        return mData.at(CantorParingFunction(d0.GetId(), d1.GetId()));
+    }
+
+    friend DofMatrixContainer operator+(DofMatrixContainer lhs, const DofMatrixContainer& rhs)
+    {
+        lhs += rhs;
+        return lhs;
+    }
+
+    friend DofMatrixContainer operator*(DofMatrixContainer lhs, double scalar)
+    {
+        lhs *= scalar;
+        return lhs;
+    }
+
+    friend std::ostream& operator<<(std::ostream& out, const DofMatrixContainer<T>& dofMatrix)
+    {
+        for (auto const& data : dofMatrix.mData)
+        {
+            auto xy = CantorPairingFunctionReverse(data.first);
+            out << "=== " << xy.first << " " << xy.second << " ==="  << std::endl;
+            out << data.second << std::endl;
+        }
+        out << "====" << std::endl;
+        return out;
+    }
+
+private:
+    //! @brief https://en.wikipedia.org/wiki/Pairing_function#Cantor_pairing_function
+    //! maps NxN --> N uniquely, deterministic, nice.
+    static int CantorParingFunction(int k1, int k2)
+    {
+        return k2 + (k1 + k2) * (k1 + k2 + 1) / 2;
+    }
+
+    static std::pair<int, int> CantorPairingFunctionReverse(int z)
+    {
+        int w = std::floor((std::sqrt(8 * z + 1) - 1) / 2);
+        int t = (w * w + w) / 2;
+        return std::make_pair(z - t, w - z + t);
+    }
+
+    std::map<int, T> mData;
+};
+} /* NuTo */

--- a/src/mechanics/nodes/DofMatrixSparse.h
+++ b/src/mechanics/nodes/DofMatrixSparse.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include "mechanics/nodes/DofMatrixContainer.h"
+#include <eigen3/Eigen/Sparse>
 
 namespace NuTo
 {
 //! @brief dof container that is also capable of performing calculations.
 template <typename T>
-using DofMatrix = DofMatrixContainer<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>;
+using DofMatrixSparse = DofMatrixContainer<Eigen::SparseMatrix<T>>;
 }
 

--- a/test/mechanics/cell/Cell.cpp
+++ b/test/mechanics/cell/Cell.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(CellLetsSee)
     fakeit::When(Method(intType, GetLocalIntegrationPointCoordinates).Using(2)).AlwaysReturn(Eigen::Vector2d({a, a}));
     fakeit::When(Method(intType, GetLocalIntegrationPointCoordinates).Using(3)).AlwaysReturn(Eigen::Vector2d({-a, a}));
 
-    NuTo::LinearElasticLaw2D law(E, 0.0);
+    NuTo::Laws::LinearElastic<2> law(E, 0.0, NuTo::ePlaneState::PLANE_STRAIN);
     NuTo::IntegrandLinearElastic<2> integrand({dofDispl}, law);
 
     NuTo::Cell<2> cell(coordinateElement, elements, intType.get(), integrand);

--- a/test/mechanics/constitutive/CMakeLists.txt
+++ b/test/mechanics/constitutive/CMakeLists.txt
@@ -18,6 +18,10 @@ add_unit_test(IPConstitutiveLaw
     mechanics/constitutive/inputoutput/ConstitutiveIOMap.cpp
     )
 
+add_unit_test(EngineeringStrainInvariants)
+add_unit_test(EngineeringStrainPDE)
+add_unit_test(EngineeringStressPDE)
+
 add_subdirectory(damageLaws)
 add_subdirectory(inputoutput)
 add_subdirectory(laws)

--- a/test/mechanics/constitutive/EngineeringStrainInvariants.cpp
+++ b/test/mechanics/constitutive/EngineeringStrainInvariants.cpp
@@ -1,0 +1,45 @@
+#include "BoostUnitTest.h"
+#include <eigen3/Eigen/Dense> // for Eigen::determinant()
+#include "mechanics/constitutive/EngineeringStrainInvariants.h"
+
+using namespace NuTo::EngineeringStrainInvariants;
+using Strain = NuTo::EngineeringStrainPDE<3>; 
+
+BOOST_AUTO_TEST_CASE(TensorToTensor)
+{
+    Strain v = Strain::Random();
+    Eigen::Matrix3d m;
+    m << v[0], .5 * v[5], .5 * v[4], .5 * v[5], v[1], .5 * v[3], .5 * v[4], .5 * v[3], v[2];
+    BoostUnitTest::CheckEigenMatrix(ToTensor(v), m);
+}
+
+BOOST_AUTO_TEST_CASE(TensorInvariantI1)
+{
+    Strain v = Strain::Random();
+    BOOST_CHECK_CLOSE(InvariantI1(v), ToTensor(v).trace(), 1.e-10);
+}
+
+BOOST_AUTO_TEST_CASE(TensorInvariantI2)
+{
+    Strain v = Strain::Random();
+    auto m = ToTensor(v);
+    BOOST_CHECK_CLOSE(InvariantI2(v), .5 * (m.trace() * m.trace() - (m * m).trace()), 1.e-10);
+}
+
+BOOST_AUTO_TEST_CASE(TensorInvariantI3)
+{
+    Strain v = Strain::Random();
+    BOOST_CHECK_CLOSE(InvariantI3(v), ToTensor(v).determinant(), 1.e-10);
+}
+
+BOOST_AUTO_TEST_CASE(TensorInvariantJ2)
+{
+    Strain v = Strain::Random();
+    BOOST_CHECK_CLOSE(InvariantJ2(v), 1. / 3. * InvariantI1(v) * InvariantI1(v) - InvariantI2(v), 1.e-10);
+}
+
+BOOST_AUTO_TEST_CASE(TensorDeviatoric)
+{
+    Strain v = Strain::Random();
+    BOOST_CHECK_CLOSE(InvariantJ2(v), -InvariantI2(Deviatoric(v)), 1.e-10);
+}

--- a/test/mechanics/constitutive/EngineeringStrainInvariants.cpp
+++ b/test/mechanics/constitutive/EngineeringStrainInvariants.cpp
@@ -16,30 +16,30 @@ BOOST_AUTO_TEST_CASE(TensorToTensor)
 BOOST_AUTO_TEST_CASE(TensorInvariantI1)
 {
     Strain v = Strain::Random();
-    BOOST_CHECK_CLOSE(InvariantI1(v), ToTensor(v).trace(), 1.e-10);
+    BOOST_CHECK_CLOSE(I1(v), ToTensor(v).trace(), 1.e-10);
 }
 
 BOOST_AUTO_TEST_CASE(TensorInvariantI2)
 {
     Strain v = Strain::Random();
     auto m = ToTensor(v);
-    BOOST_CHECK_CLOSE(InvariantI2(v), .5 * (m.trace() * m.trace() - (m * m).trace()), 1.e-10);
+    BOOST_CHECK_CLOSE(I2(v), .5 * (m.trace() * m.trace() - (m * m).trace()), 1.e-10);
 }
 
 BOOST_AUTO_TEST_CASE(TensorInvariantI3)
 {
     Strain v = Strain::Random();
-    BOOST_CHECK_CLOSE(InvariantI3(v), ToTensor(v).determinant(), 1.e-10);
+    BOOST_CHECK_CLOSE(I3(v), ToTensor(v).determinant(), 1.e-10);
 }
 
 BOOST_AUTO_TEST_CASE(TensorInvariantJ2)
 {
     Strain v = Strain::Random();
-    BOOST_CHECK_CLOSE(InvariantJ2(v), 1. / 3. * InvariantI1(v) * InvariantI1(v) - InvariantI2(v), 1.e-10);
+    BOOST_CHECK_CLOSE(J2(v), 1. / 3. * I1(v) * I1(v) - I2(v), 1.e-10);
 }
 
 BOOST_AUTO_TEST_CASE(TensorDeviatoric)
 {
     Strain v = Strain::Random();
-    BOOST_CHECK_CLOSE(InvariantJ2(v), -InvariantI2(Deviatoric(v)), 1.e-10);
+    BOOST_CHECK_CLOSE(J2(v), -I2(Deviatoric(v)), 1.e-10);
 }

--- a/test/mechanics/constitutive/EngineeringStrainPDE.cpp
+++ b/test/mechanics/constitutive/EngineeringStrainPDE.cpp
@@ -1,0 +1,9 @@
+#include "BoostUnitTest.h"
+#include "TypeTraits.h"
+#include "mechanics/constitutive/EngineeringStrainPDE.h"
+
+BOOST_AUTO_TEST_CASE(EngineeringStrainCopyMove)
+{
+    NuTo::Test::Copy<NuTo::EngineeringStrainPDE<3>>();
+    NuTo::Test::Move<NuTo::EngineeringStrainPDE<3>>();
+}

--- a/test/mechanics/constitutive/EngineeringStressPDE.cpp
+++ b/test/mechanics/constitutive/EngineeringStressPDE.cpp
@@ -1,0 +1,9 @@
+#include "BoostUnitTest.h"
+#include "TypeTraits.h"
+#include "mechanics/constitutive/EngineeringStressPDE.h"
+
+BOOST_AUTO_TEST_CASE(EngineeringStrainCopyMove)
+{
+    NuTo::Test::Copy<NuTo::EngineeringStressPDE<3>>();
+    NuTo::Test::Move<NuTo::EngineeringStressPDE<3>>();
+}

--- a/test/mechanics/constitutive/laws/CMakeLists.txt
+++ b/test/mechanics/constitutive/laws/CMakeLists.txt
@@ -54,3 +54,5 @@ add_unit_test(Creep
     mechanics/constitutive/ConstitutiveBase.cpp
     mechanics/constitutive/ConstitutiveEnum.cpp
     )
+
+add_unit_test(LinearElastic)

--- a/test/mechanics/constitutive/laws/LinearElastic.cpp
+++ b/test/mechanics/constitutive/laws/LinearElastic.cpp
@@ -12,15 +12,14 @@ BOOST_AUTO_TEST_CASE(LinearElastic1D)
     auto C = law.Tangent(NuTo::EngineeringStrainPDE<1>::Zero());
     BoostUnitTest::CheckEigenMatrix(C, Eigen::Matrix<double, 1, 1>::Constant(E));
 
-    // I trust Eigen::operator* and check LinearElastic::Stress(...) only once here
-    
     BOOST_CHECK_CLOSE(law.Stress(NuTo::EngineeringStrainPDE<1>::Constant(12))[0], E * 12, 1.e-10);
 }
 
 BOOST_AUTO_TEST_CASE(LinearElastic2DPlaneStress)
 {
     NuTo::Laws::LinearElastic<2> law(E, nu, NuTo::ePlaneState::PLANE_STRESS);
-    auto C = law.Tangent(NuTo::EngineeringStrainPDE<2>::Zero());
+    NuTo::EngineeringStrainPDE<2> strain = NuTo::EngineeringStrainPDE<2>::Random();
+    auto C = law.Tangent(strain);
 
     Eigen::Matrix3d expected = Eigen::Matrix3d::Zero();
     expected(0, 0) = 1;
@@ -30,12 +29,14 @@ BOOST_AUTO_TEST_CASE(LinearElastic2DPlaneStress)
     expected(2, 2) = (1 - nu) / 2;
     expected *= E / (1 - nu * nu);
     BoostUnitTest::CheckEigenMatrix(C, expected);
+    BoostUnitTest::CheckEigenMatrix(law.Stress(strain), expected * strain);
 }
 
 BOOST_AUTO_TEST_CASE(LinearElastic2DPlaneStrain)
 {
     NuTo::Laws::LinearElastic<2> law(E, nu, NuTo::ePlaneState::PLANE_STRAIN);
-    auto C = law.Tangent(NuTo::EngineeringStrainPDE<2>::Zero());
+    NuTo::EngineeringStrainPDE<2> strain = NuTo::EngineeringStrainPDE<2>::Random();
+    auto C = law.Tangent(strain);
 
     Eigen::Matrix3d expected = Eigen::Matrix3d::Zero();
     expected(0, 0) = 1 - nu;
@@ -45,12 +46,14 @@ BOOST_AUTO_TEST_CASE(LinearElastic2DPlaneStrain)
     expected(2, 2) = (1 - 2 * nu) / 2;
     expected *= E / ((1 + nu) * (1 - 2 * nu));
     BoostUnitTest::CheckEigenMatrix(C, expected);
+    BoostUnitTest::CheckEigenMatrix(law.Stress(strain), expected * strain);
 }
 
 BOOST_AUTO_TEST_CASE(LinearElastic3D)
 {
     NuTo::Laws::LinearElastic<3> law(E, nu);
-    auto C = law.Tangent(NuTo::EngineeringStrainPDE<3>::Zero());
+    NuTo::EngineeringStrainPDE<3> strain = NuTo::EngineeringStrainPDE<3>::Random();
+    auto C = law.Tangent(strain);
 
     Eigen::Matrix<double, 6, 6> expected = Eigen::Matrix<double, 6, 6>::Zero();
     expected(0, 0) = 1 - nu;
@@ -69,4 +72,5 @@ BOOST_AUTO_TEST_CASE(LinearElastic3D)
     expected(5, 5) = (1 - 2 * nu) / 2;
     expected *= E / ((1 + nu) * (1 - 2 * nu));
     BoostUnitTest::CheckEigenMatrix(C, expected);
+    BoostUnitTest::CheckEigenMatrix(law.Stress(strain), expected * strain);
 }

--- a/test/mechanics/constitutive/laws/LinearElastic.cpp
+++ b/test/mechanics/constitutive/laws/LinearElastic.cpp
@@ -1,0 +1,72 @@
+#include "BoostUnitTest.h"
+#include "mechanics/constitutive/laws/LinearElastic.h"
+
+constexpr double E = 6174;
+constexpr double nu = 0.36;
+
+// https://en.wikipedia.org/wiki/Hooke%27s_law
+
+BOOST_AUTO_TEST_CASE(LinearElastic1D)
+{
+    NuTo::Laws::LinearElastic<1> law(E, nu);
+    auto C = law.Tangent(NuTo::EngineeringStrainPDE<1>::Zero());
+    BoostUnitTest::CheckEigenMatrix(C, Eigen::Matrix<double, 1, 1>::Constant(E));
+
+    // I trust Eigen::operator* and check LinearElastic::Stress(...) only once here
+    
+    BOOST_CHECK_CLOSE(law.Stress(NuTo::EngineeringStrainPDE<1>::Constant(12))[0], E * 12, 1.e-10);
+}
+
+BOOST_AUTO_TEST_CASE(LinearElastic2DPlaneStress)
+{
+    NuTo::Laws::LinearElastic<2> law(E, nu, NuTo::ePlaneState::PLANE_STRESS);
+    auto C = law.Tangent(NuTo::EngineeringStrainPDE<2>::Zero());
+
+    Eigen::Matrix3d expected = Eigen::Matrix3d::Zero();
+    expected(0, 0) = 1;
+    expected(1, 1) = 1;
+    expected(0, 1) = nu;
+    expected(1, 0) = nu;
+    expected(2, 2) = (1 - nu) / 2;
+    expected *= E / (1 - nu * nu);
+    BoostUnitTest::CheckEigenMatrix(C, expected);
+}
+
+BOOST_AUTO_TEST_CASE(LinearElastic2DPlaneStrain)
+{
+    NuTo::Laws::LinearElastic<2> law(E, nu, NuTo::ePlaneState::PLANE_STRAIN);
+    auto C = law.Tangent(NuTo::EngineeringStrainPDE<2>::Zero());
+
+    Eigen::Matrix3d expected = Eigen::Matrix3d::Zero();
+    expected(0, 0) = 1 - nu;
+    expected(1, 1) = 1 - nu;
+    expected(0, 1) = nu;
+    expected(1, 0) = nu;
+    expected(2, 2) = (1 - 2 * nu) / 2;
+    expected *= E / ((1 + nu) * (1 - 2 * nu));
+    BoostUnitTest::CheckEigenMatrix(C, expected);
+}
+
+BOOST_AUTO_TEST_CASE(LinearElastic3D)
+{
+    NuTo::Laws::LinearElastic<3> law(E, nu);
+    auto C = law.Tangent(NuTo::EngineeringStrainPDE<3>::Zero());
+
+    Eigen::Matrix<double, 6, 6> expected = Eigen::Matrix<double, 6, 6>::Zero();
+    expected(0, 0) = 1 - nu;
+    expected(1, 1) = 1 - nu;
+    expected(2, 2) = 1 - nu;
+
+    expected(0, 1) = nu;
+    expected(1, 0) = nu;
+    expected(0, 2) = nu;
+    expected(2, 0) = nu;
+    expected(2, 1) = nu;
+    expected(1, 2) = nu;
+
+    expected(3, 3) = (1 - 2 * nu) / 2;
+    expected(4, 4) = (1 - 2 * nu) / 2;
+    expected(5, 5) = (1 - 2 * nu) / 2;
+    expected *= E / ((1 + nu) * (1 - 2 * nu));
+    BoostUnitTest::CheckEigenMatrix(C, expected);
+}

--- a/test/mechanics/nodes/CMakeLists.txt
+++ b/test/mechanics/nodes/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_unit_test(DofContainer)
 add_unit_test(DofVector)
 add_unit_test(DofMatrix)
+add_unit_test(DofMatrixSparse)
 add_unit_test(DofType)
 add_unit_test(NodeSimple)
 add_unit_test(NodeBase)

--- a/test/mechanics/nodes/DofMatrix.cpp
+++ b/test/mechanics/nodes/DofMatrix.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(DofMatrixUninitializedAddition)
     CheckDofMatrix(dofMatrix0, dof0, dof1);
 }
 
-BOOST_AUTO_TEST_CASE(DofVectorStream)
+BOOST_AUTO_TEST_CASE(DofMatrixStream)
 {
     NuTo::DofType dof0("foo", 1, 0);
     NuTo::DofType dof1("bar", 1, 1);
@@ -65,4 +65,6 @@ BOOST_AUTO_TEST_CASE(DofVectorStream)
     BOOST_CHECK(ss.str().find("23") != std::string::npos);
     BOOST_CHECK(ss.str().find("32") != std::string::npos);
     BOOST_CHECK(ss.str().find("33") != std::string::npos);
+
+    BOOST_TEST_MESSAGE("" << dofMatrix);
 }

--- a/test/mechanics/nodes/DofMatrixSparse.cpp
+++ b/test/mechanics/nodes/DofMatrixSparse.cpp
@@ -1,0 +1,86 @@
+#include "BoostUnitTest.h"
+#include "mechanics/nodes/DofMatrixSparse.h"
+#include <sstream>
+
+Eigen::SparseMatrix<int> Constant(int rows, int cols, int val)
+{
+    Eigen::SparseMatrix<int> m(rows, cols);
+    for (int i = 0; i < rows; ++i)
+        for (int j = 0; j < cols; ++j)
+            m.coeffRef(i,j) = val;
+    return m;
+}
+
+void CheckConstant(const Eigen::SparseMatrix<int>& m, int rows, int cols, int val)
+{
+    for (int i = 0; i < rows; ++i)
+        for (int j = 0; j < cols; ++j)
+            BOOST_CHECK_EQUAL(m.coeff(i,j), val);
+}
+
+NuTo::DofMatrixSparse<int> Get(const NuTo::DofType& d0, const NuTo::DofType& d1)
+{
+    NuTo::DofMatrixSparse<int> dofMatrix;
+    dofMatrix(d0, d0) = Constant(2, 2, 22);
+    dofMatrix(d0, d1) = Constant(2, 3, 23);
+    dofMatrix(d1, d0) = Constant(3, 2, 32);
+    dofMatrix(d1, d1) = Constant(3, 3, 33);
+    return dofMatrix;
+}
+
+void CheckDofMatrix(const NuTo::DofMatrixSparse<int>& m, const NuTo::DofType& d0, const NuTo::DofType& d1)
+{
+    CheckConstant(m(d0, d0), 2, 2, 44);
+    CheckConstant(m(d0, d1), 2, 3, 46);
+    CheckConstant(m(d1, d0), 3, 2, 64);
+    CheckConstant(m(d1, d1), 3, 3, 66);
+}
+
+BOOST_AUTO_TEST_CASE(DofMatrixAdditionMultiplication)
+{
+    NuTo::DofType dof0("foo", 1, 0);
+    NuTo::DofType dof1("bar", 1, 1);
+
+    NuTo::DofMatrixSparse<int> dofMatrix0 = Get(dof0, dof1);
+    NuTo::DofMatrixSparse<int> dofMatrix1 = Get(dof0, dof1);
+
+    dofMatrix0 += dofMatrix1;
+    CheckDofMatrix(dofMatrix0, dof0, dof1);
+
+    dofMatrix1 *= 2;
+    CheckDofMatrix(dofMatrix1, dof0, dof1);
+}
+
+BOOST_AUTO_TEST_CASE(DofMatrixUninitializedAddition)
+{
+    NuTo::DofType dof0("foo", 1, 0);
+    NuTo::DofType dof1("bar", 1, 1);
+
+    NuTo::DofMatrixSparse<int> dofMatrix0;
+    NuTo::DofMatrixSparse<int> dofMatrix1 = Get(dof0, dof1);
+
+    dofMatrix0 += dofMatrix1;
+    dofMatrix0 += dofMatrix1;
+    CheckDofMatrix(dofMatrix0, dof0, dof1);
+}
+
+BOOST_AUTO_TEST_CASE(DofMatrixStream)
+{
+    NuTo::DofType dof0("foo", 1, 0);
+    NuTo::DofType dof1("bar", 1, 1);
+    NuTo::DofMatrixSparse<int> dofMatrix = Get(dof0, dof1);
+    std::stringstream ss;
+    ss << dofMatrix;
+    // header:
+    BOOST_CHECK(ss.str().find("=== 0 0 ===") != std::string::npos);
+    BOOST_CHECK(ss.str().find("=== 0 1 ===") != std::string::npos);
+    BOOST_CHECK(ss.str().find("=== 1 0 ===") != std::string::npos);
+    BOOST_CHECK(ss.str().find("=== 1 1 ===") != std::string::npos);
+    // values:
+    BOOST_CHECK(ss.str().find("22") != std::string::npos);
+    BOOST_CHECK(ss.str().find("23") != std::string::npos);
+    BOOST_CHECK(ss.str().find("32") != std::string::npos);
+    BOOST_CHECK(ss.str().find("33") != std::string::npos);
+
+    BOOST_TEST_MESSAGE("" << dofMatrix);
+}


### PR DESCRIPTION
To start somewhere, I implemented a simple linear elastic law. Since I wanted to use proper EngineeringStrain and EngineeringStress classes, I added the suffix _PDE_. Since the Voigt strain contains a division by 2 in the lower diagonal, it is important to differentiate between those two. Thus, a simple
~~~c++
using Stress = Eigen::Matrix<...>;
using Strain = Eigen::Matrix<...>;
~~~
is not enough and I chose define two separate classes that inherit from `Eigen`. 

Comments/wishes/changes?

Please feel free to provide commits on your own :)