### PR TITLE
Pde group

### DIFF
--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -28,6 +28,19 @@ public:
     typedef std::vector<T*> parent;
     typedef boost::indirect_iterator<typename parent::iterator> GroupIterator;
 
+    Group() = default;
+
+    Group(T& element)
+    {
+        Add(element);
+    }
+    
+    Group(std::vector<std::reference_wrapper<T>> elements)
+    {
+        for (auto element : elements)
+            Add(element);
+    }
+
     void Add(T& element)
     {
         auto it = std::lower_bound(pbegin(), pend(), &element, TCompare());
@@ -41,6 +54,11 @@ public:
         if (result == pcend())
             return false;
         return *result == &element;
+    }
+
+    bool Empty() const
+    {
+        return size() == 0;
     }
 
     GroupIterator begin()

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -20,6 +20,18 @@ struct IdSmaller
 
 class Utils;
 
+//! @brief Ordered container class for elements, nodes and the like. No duplicates.
+//!
+//! The group saves pointers to its members but can be iterated through
+//! by value. By default the members are sorted by id (this must be unique)
+//! that is accessed by calling Id(), e.g as provided by NuTo::UniqueId. Other
+//! methods operating on the group also use this comparator.
+//! This behaviour can be changed by providing a different comparator but the basis
+//! of the comparison has to be a unique attribute of the group member.
+//! See test file (CutomCompare).
+//!
+//! @tparam T type of group members
+//! @tparam TCompare functor representing the comparison operation used for sorting
 template <typename T, typename TCompare = IdSmaller<T>>
 class Group : private std::vector<T*>
 {
@@ -29,19 +41,23 @@ public:
     typedef std::vector<T*> parent;
     typedef boost::indirect_iterator<typename parent::iterator> GroupIterator;
 
+    //! @brief Empty group
     Group() = default;
 
+    //! @brief Group containing one element
     Group(T& element)
     {
         Add(element);
     }
 
+    //! @brief Group containing multiple elements
     Group(std::vector<std::reference_wrapper<T>> elements)
     {
         for (auto element : elements)
             Add(element);
     }
 
+    //! @brief Add element to group
     void Add(T& element)
     {
         auto it = std::lower_bound(pcbegin(), pcend(), &element, TCompare());
@@ -49,6 +65,11 @@ public:
             parent::insert(it, &element);
     }
 
+    //! @brief True if element is contained in group
+    //!
+    //! Comment:
+    //! Search for element is done using Comparator,
+    //! Equality is checked by pointer equivalence.
     bool Contains(const T& element) const
     {
         auto result = std::lower_bound(pcbegin(), pcend(), &element, TCompare());
@@ -57,21 +78,25 @@ public:
         return *result == &element;
     }
 
+    //! @brief True if group is empty
     bool Empty() const
     {
         return Size() == 0;
     }
 
+    //! @brief Number of constituents
     auto Size() const
     {
         return size();
     }
 
+    //! @brief Iterate over group elements (by value not pointer)
     GroupIterator begin()
     {
         return parent::begin();
     }
 
+    //! @brief Iterate over group elements (by value not pointer)
     GroupIterator end()
     {
         return parent::end();
@@ -96,6 +121,7 @@ private:
     using parent::size;
 };
 
+//! @brief Unite two groups
 template <typename T, typename TCompare>
 static Group<T, TCompare> Unite(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
 {
@@ -105,6 +131,7 @@ static Group<T, TCompare> Unite(const Group<T, TCompare>& one, const Group<T, TC
     return newGroup;
 }
 
+//! @brief Returns group with elements of group one that are not in group two
 template <typename T, typename TCompare>
 static Group<T, TCompare> Difference(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
 {
@@ -114,6 +141,7 @@ static Group<T, TCompare> Difference(const Group<T, TCompare>& one, const Group<
     return newGroup;
 }
 
+//! @brief Returns group with elements that are in both groups
 template <typename T, typename TCompare>
 static Group<T, TCompare> Intersection(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
 {
@@ -123,6 +151,7 @@ static Group<T, TCompare> Intersection(const Group<T, TCompare>& one, const Grou
     return newGroup;
 }
 
+//! @brief Returns group with elements that are only in one group not in both
 template <typename T, typename TCompare>
 static Group<T, TCompare> SymmetricDifference(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
 {

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -12,7 +12,7 @@ namespace Groups
 template <typename T>
 struct IdCompare
 {
-    bool operator()(T* a, T* b) const
+    bool operator()(const T* a, const T* b) const
     {
         return a->Id() < b->Id();
     }

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -62,13 +62,12 @@ public:
         return parent::cend();
     }
 
-    bool Contains(const T& element)
+    bool Contains(const T& element) const
     {
-        auto result = std::find(parent::begin(), parent::end(), &element);
-        if (result != parent::end())
-            return true;
-        else
+        auto result = std::lower_bound(pcbegin(), pcend(), &element, TCompare());
+        if (result == pcend())
             return false;
+        return *result == &element;
     }
 
     using parent::size;

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -76,42 +76,43 @@ public:
 };
 
 
-template <typename T>
-Group<T> Unite(const Group<T>& one, const Group<T>& two)
+template <typename T, typename TCompare>
+Group<T, TCompare> Unite(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
 {
-    Group<T> newGroup;
-    std::insert_iterator<Group<T>> newGroupInsertIterator(newGroup, newGroup.pbegin());
-    std::set_union(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator);
+    Group<T, TCompare> newGroup;
+    std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+    std::set_union(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
     return newGroup;
 }
 
 
-template <typename T>
-Group<T> Difference(const Group<T>& one, const Group<T>& two)
+template <typename T, typename TCompare>
+Group<T, TCompare> Difference(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
 {
-    Group<T> newGroup;
-    std::insert_iterator<Group<T>> newGroupInsertIterator(newGroup, newGroup.pbegin());
-    std::set_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator);
+    Group<T, TCompare> newGroup;
+    std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+    std::set_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
     return newGroup;
 }
 
 
-template <typename T>
-Group<T> Intersection(const Group<T>& one, const Group<T>& two)
+template <typename T, typename TCompare>
+Group<T, TCompare> Intersection(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
 {
-    Group<T> newGroup;
-    std::insert_iterator<Group<T>> newGroupInsertIterator(newGroup, newGroup.pbegin());
-    std::set_intersection(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator);
+    Group<T, TCompare> newGroup;
+    std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+    std::set_intersection(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
     return newGroup;
 }
 
 
-template <typename T>
-Group<T> SymmetricDifference(const Group<T>& one, const Group<T>& two)
+template <typename T, typename TCompare>
+Group<T, TCompare> SymmetricDifference(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
 {
-    Group<T> newGroup;
-    std::insert_iterator<Group<T>> newGroupInsertIterator(newGroup, newGroup.pbegin());
-    std::set_symmetric_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator);
+    Group<T, TCompare> newGroup;
+    std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+    std::set_symmetric_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator,
+                                  TCompare());
     return newGroup;
 }
 

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <algorithm>
-#include <set>
+#include <vector>
 #include <boost/iterator/indirect_iterator.hpp>
 
 namespace NuTo
@@ -19,15 +19,17 @@ struct IdCompare
 };
 
 template <typename T, typename TCompare = IdCompare<T>>
-class Group : private std::set<T*, TCompare>
+class Group : private std::vector<T*>
 {
 public:
-    typedef std::set<T*, TCompare> parent;
+    typedef std::vector<T*> parent;
     typedef boost::indirect_iterator<typename parent::iterator> GroupIterator;
 
     void AddMember(T& element)
     {
-        parent::insert(&element);
+        auto it = std::lower_bound(pbegin(), pend(), &element, TCompare());
+        if (it == pend() || TCompare()(&element, *it))
+            parent::insert(it, &element);
     }
 
     GroupIterator begin()

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -25,7 +25,7 @@ public:
     typedef std::vector<T*> parent;
     typedef boost::indirect_iterator<typename parent::iterator> GroupIterator;
 
-    void AddMember(T& element)
+    void Add(T& element)
     {
         auto it = std::lower_bound(pbegin(), pend(), &element, TCompare());
         if (it == pend() || TCompare()(&element, *it))

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -10,7 +10,7 @@ namespace Groups
 {
 
 template <typename T>
-struct IdCompare
+struct IdSmaller
 {
     bool operator()(const T* a, const T* b) const
     {
@@ -20,7 +20,7 @@ struct IdCompare
 
 class Utils;
 
-template <typename T, typename TCompare = IdCompare<T>>
+template <typename T, typename TCompare = IdSmaller<T>>
 class Group : private std::vector<T*>
 {
     friend class std::insert_iterator<Group>;

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -18,9 +18,12 @@ struct IdCompare
     }
 };
 
+class Utils;
+
 template <typename T, typename TCompare = IdCompare<T>>
 class Group : private std::vector<T*>
 {
+    friend class Utils;
 public:
     typedef std::vector<T*> parent;
     typedef boost::indirect_iterator<typename parent::iterator> GroupIterator;
@@ -32,6 +35,14 @@ public:
             parent::insert(it, &element);
     }
 
+    bool Contains(const T& element) const
+    {
+        auto result = std::lower_bound(pcbegin(), pcend(), &element, TCompare());
+        if (result == pcend())
+            return false;
+        return *result == &element;
+    }
+
     GroupIterator begin()
     {
         return parent::begin();
@@ -41,6 +52,17 @@ public:
     {
         return parent::end();
     }
+
+    using parent::size;
+    using parent::insert;
+    using typename parent::iterator;
+    using typename parent::value_type;
+
+private:
+    /**
+     * The following methods should be hidden from the user. They are
+     * only used by class Utils that is a friend.
+     */
 
     typename parent::iterator pbegin()
     {
@@ -61,61 +83,49 @@ public:
     {
         return parent::cend();
     }
-
-    bool Contains(const T& element) const
-    {
-        auto result = std::lower_bound(pcbegin(), pcend(), &element, TCompare());
-        if (result == pcend())
-            return false;
-        return *result == &element;
-    }
-
-    using parent::size;
-    using typename parent::iterator;
-    using typename parent::value_type;
-    using parent::insert;
 };
 
-
-template <typename T, typename TCompare>
-Group<T, TCompare> Unite(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
+class Utils
 {
-    Group<T, TCompare> newGroup;
-    std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
-    std::set_union(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
-    return newGroup;
-}
+public:
+    template <typename T, typename TCompare>
+    static Group<T, TCompare> Unite(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
+    {
+        Group<T, TCompare> newGroup;
+        std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+        std::set_union(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
+        return newGroup;
+    }
 
+    template <typename T, typename TCompare>
+    static Group<T, TCompare> Difference(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
+    {
+        Group<T, TCompare> newGroup;
+        std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+        std::set_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
+        return newGroup;
+    }
 
-template <typename T, typename TCompare>
-Group<T, TCompare> Difference(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
-{
-    Group<T, TCompare> newGroup;
-    std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
-    std::set_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
-    return newGroup;
-}
+    template <typename T, typename TCompare>
+    static Group<T, TCompare> Intersection(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
+    {
+        Group<T, TCompare> newGroup;
+        std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+        std::set_intersection(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator,
+                              TCompare());
+        return newGroup;
+    }
 
-
-template <typename T, typename TCompare>
-Group<T, TCompare> Intersection(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
-{
-    Group<T, TCompare> newGroup;
-    std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
-    std::set_intersection(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
-    return newGroup;
-}
-
-
-template <typename T, typename TCompare>
-Group<T, TCompare> SymmetricDifference(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
-{
-    Group<T, TCompare> newGroup;
-    std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
-    std::set_symmetric_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator,
-                                  TCompare());
-    return newGroup;
-}
+    template <typename T, typename TCompare>
+    static Group<T, TCompare> SymmetricDifference(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
+    {
+        Group<T, TCompare> newGroup;
+        std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+        std::set_symmetric_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator,
+                                      TCompare());
+        return newGroup;
+    }
+}; // class Utils
 
 } // namespace Group
 } // namespace NuTo

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -10,10 +10,19 @@ namespace Groups
 {
 
 template <typename T>
-class Group : private std::set<T*>
+struct IdCompare
+{
+    bool operator()(T* a, T* b) const
+    {
+        return a->Id() < b->Id();
+    }
+};
+
+template <typename T, typename TCompare = IdCompare<T>>
+class Group : private std::set<T*, TCompare>
 {
 public:
-    typedef std::set<T*> parent;
+    typedef std::set<T*, TCompare> parent;
     typedef boost::indirect_iterator<typename parent::iterator> GroupIterator;
 
     void AddMember(T& element)

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+#include <boost/iterator/indirect_iterator.hpp>
+
+namespace NuTo
+{
+namespace Groups
+{
+
+template <typename T>
+class Group : private std::vector<T*>
+{
+public:
+    typedef std::vector<T*> parent;
+    typedef boost::indirect_iterator<typename parent::iterator> GroupIterator;
+
+    void AddMember(T& element)
+    {
+        parent::push_back(&element);
+    }
+
+    GroupIterator begin()
+    {
+        return parent::begin();
+    }
+
+    GroupIterator end()
+    {
+        return parent::end();
+    }
+
+    typename parent::iterator pbegin()
+    {
+        return parent::begin();
+    }
+
+    typename parent::iterator pend()
+    {
+        return parent::end();
+    }
+
+    typename parent::const_iterator pcbegin() const
+    {
+        return parent::cbegin();
+    }
+
+    typename parent::const_iterator pcend() const
+    {
+        return parent::cend();
+    }
+
+    bool Contains(const T& element)
+    {
+        auto result = std::find(parent::begin(), parent::end(), &element);
+        if (result != parent::end())
+            return true;
+        else
+            return false;
+    }
+
+    using parent::size;
+    using typename parent::iterator;
+    using typename parent::value_type;
+    using parent::insert;
+};
+
+
+template <typename T>
+Group<T> Unite(const Group<T>& one, const Group<T>& two)
+{
+    Group<T> newGroup;
+    std::insert_iterator<Group<T>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+    std::set_union(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator);
+    return newGroup;
+}
+
+
+template <typename T>
+Group<T> Difference(const Group<T>& one, const Group<T>& two)
+{
+    Group<T> newGroup;
+    std::insert_iterator<Group<T>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+    std::set_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator);
+    return newGroup;
+}
+
+
+template <typename T>
+Group<T> Intersection(const Group<T>& one, const Group<T>& two)
+{
+    Group<T> newGroup;
+    std::insert_iterator<Group<T>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+    std::set_intersection(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator);
+    return newGroup;
+}
+
+
+template <typename T>
+Group<T> SymmetricDifference(const Group<T>& one, const Group<T>& two)
+{
+    Group<T> newGroup;
+    std::insert_iterator<Group<T>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+    std::set_symmetric_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator);
+    return newGroup;
+}
+
+} // namespace Group
+} // namespace NuTo

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <algorithm>
-#include <vector>
+#include <set>
 #include <boost/iterator/indirect_iterator.hpp>
 
 namespace NuTo
@@ -10,15 +10,15 @@ namespace Groups
 {
 
 template <typename T>
-class Group : private std::vector<T*>
+class Group : private std::set<T*>
 {
 public:
-    typedef std::vector<T*> parent;
+    typedef std::set<T*> parent;
     typedef boost::indirect_iterator<typename parent::iterator> GroupIterator;
 
     void AddMember(T& element)
     {
-        parent::push_back(&element);
+        parent::insert(&element);
     }
 
     GroupIterator begin()

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -23,7 +23,6 @@ class Utils;
 template <typename T, typename TCompare = IdCompare<T>>
 class Group : private std::vector<T*>
 {
-    friend class Utils;
     friend class std::insert_iterator<Group>;
 
 public:
@@ -45,8 +44,8 @@ public:
 
     void Add(T& element)
     {
-        auto it = std::lower_bound(pbegin(), pend(), &element, TCompare());
-        if (it == pend() || TCompare()(&element, *it))
+        auto it = std::lower_bound(pcbegin(), pcend(), &element, TCompare());
+        if (it == pcend() || TCompare()(&element, *it))
             parent::insert(it, &element);
     }
 
@@ -62,7 +61,7 @@ public:
     {
         return Size() == 0;
     }
-    
+
     auto Size() const
     {
         return size();
@@ -78,21 +77,9 @@ public:
         return parent::end();
     }
 
-private:
-     using parent::size;
-    /**
-     * The following methods should be hidden from the user. They are
-     * only used by class Utils that is a friend.
-     */
-
     typename parent::iterator pbegin()
     {
         return parent::begin();
-    }
-
-    typename parent::iterator pend()
-    {
-        return parent::end();
     }
 
     typename parent::const_iterator pcbegin() const
@@ -104,49 +91,47 @@ private:
     {
         return parent::cend();
     }
+
+private:
+    using parent::size;
 };
 
-class Utils
+template <typename T, typename TCompare>
+static Group<T, TCompare> Unite(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
 {
-public:
-    template <typename T, typename TCompare>
-    static Group<T, TCompare> Unite(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
-    {
-        Group<T, TCompare> newGroup;
-        std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
-        std::set_union(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
-        return newGroup;
-    }
+    Group<T, TCompare> newGroup;
+    std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+    std::set_union(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
+    return newGroup;
+}
 
-    template <typename T, typename TCompare>
-    static Group<T, TCompare> Difference(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
-    {
-        Group<T, TCompare> newGroup;
-        std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
-        std::set_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
-        return newGroup;
-    }
+template <typename T, typename TCompare>
+static Group<T, TCompare> Difference(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
+{
+    Group<T, TCompare> newGroup;
+    std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+    std::set_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
+    return newGroup;
+}
 
-    template <typename T, typename TCompare>
-    static Group<T, TCompare> Intersection(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
-    {
-        Group<T, TCompare> newGroup;
-        std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
-        std::set_intersection(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator,
-                              TCompare());
-        return newGroup;
-    }
+template <typename T, typename TCompare>
+static Group<T, TCompare> Intersection(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
+{
+    Group<T, TCompare> newGroup;
+    std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+    std::set_intersection(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator, TCompare());
+    return newGroup;
+}
 
-    template <typename T, typename TCompare>
-    static Group<T, TCompare> SymmetricDifference(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
-    {
-        Group<T, TCompare> newGroup;
-        std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
-        std::set_symmetric_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator,
-                                      TCompare());
-        return newGroup;
-    }
-}; // class Utils
+template <typename T, typename TCompare>
+static Group<T, TCompare> SymmetricDifference(const Group<T, TCompare>& one, const Group<T, TCompare>& two)
+{
+    Group<T, TCompare> newGroup;
+    std::insert_iterator<Group<T, TCompare>> newGroupInsertIterator(newGroup, newGroup.pbegin());
+    std::set_symmetric_difference(one.pcbegin(), one.pcend(), two.pcbegin(), two.pcend(), newGroupInsertIterator,
+                                  TCompare());
+    return newGroup;
+}
 
 } // namespace Group
 } // namespace NuTo

--- a/src/base/Group.h
+++ b/src/base/Group.h
@@ -24,6 +24,8 @@ template <typename T, typename TCompare = IdCompare<T>>
 class Group : private std::vector<T*>
 {
     friend class Utils;
+    friend class std::insert_iterator<Group>;
+
 public:
     typedef std::vector<T*> parent;
     typedef boost::indirect_iterator<typename parent::iterator> GroupIterator;
@@ -34,7 +36,7 @@ public:
     {
         Add(element);
     }
-    
+
     Group(std::vector<std::reference_wrapper<T>> elements)
     {
         for (auto element : elements)
@@ -58,7 +60,12 @@ public:
 
     bool Empty() const
     {
-        return size() == 0;
+        return Size() == 0;
+    }
+    
+    auto Size() const
+    {
+        return size();
     }
 
     GroupIterator begin()
@@ -71,12 +78,8 @@ public:
         return parent::end();
     }
 
-    using parent::size;
-    using parent::insert;
-    using typename parent::iterator;
-    using typename parent::value_type;
-
 private:
+     using parent::size;
     /**
      * The following methods should be hidden from the user. They are
      * only used by class Utils that is a friend.

--- a/test/base/CMakeLists.txt
+++ b/test/base/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_unit_test(GroupTest)
 add_subdirectory(serializeStream)

--- a/test/base/GroupTest.cpp
+++ b/test/base/GroupTest.cpp
@@ -94,11 +94,11 @@ BOOST_AUTO_TEST_CASE(CustomCompare)
     int b = 6174;
     int c = 42;
 
-    Groups::Group<int, std::less<int*>> g0;
+    Groups::Group<int, std::less<const int*>> g0;
     g0.Add(a);
     g0.Add(b);
     g0.Add(c);
-    Groups::Group<int, std::less<int*>> g1;
+    Groups::Group<int, std::less<const int*>> g1;
     g1.Add(b);
 
     auto intersection = Groups::Intersection(g0, g1);

--- a/test/base/GroupTest.cpp
+++ b/test/base/GroupTest.cpp
@@ -28,9 +28,11 @@ struct GroupTestFixture
         groupOne.AddMember(a);
         groupOne.AddMember(b);
         groupOne.AddMember(c);
+        groupOne.AddMember(a); // duplicate!
 
         groupTwo.AddMember(c);
         groupTwo.AddMember(d);
+        groupTwo.AddMember(d); // duplicate!
     }
 
     Foo a, b, c, d;

--- a/test/base/GroupTest.cpp
+++ b/test/base/GroupTest.cpp
@@ -104,3 +104,19 @@ BOOST_AUTO_TEST_CASE(CustomCompare)
     auto intersection = Groups::Utils::Intersection(g0, g1);
     BOOST_CHECK(intersection.Contains(b));
 }
+
+BOOST_AUTO_TEST_CASE(GroupCtors)
+{
+    Groups::Group<Foo> empty;
+    BOOST_CHECK(empty.Empty());
+
+    Foo a, b, c;
+    Groups::Group<Foo> one(a);
+    BOOST_CHECK(one.Contains(a));
+
+    Groups::Group<Foo> many({a, b, c, a});
+    BOOST_CHECK(many.Contains(a));
+    BOOST_CHECK(many.Contains(b));
+    BOOST_CHECK(many.Contains(c));
+    BOOST_CHECK_EQUAL(many.size(), 3);
+}

--- a/test/base/GroupTest.cpp
+++ b/test/base/GroupTest.cpp
@@ -16,12 +16,16 @@ struct Foo : FooBase
 BOOST_AUTO_TEST_CASE(ContainsTest)
 {
     Groups::Group<Foo> group;
-    Foo a;
+    Foo a, b, c, d;
     BOOST_CHECK(not group.Contains(a));
     group.Add(a);
     BOOST_CHECK(group.Contains(a));
     group.Add(a);
     BOOST_CHECK(group.Contains(a));
+    group.Add(b);
+    group.Add(c);
+    group.Add(d);
+    BOOST_CHECK(group.Contains(c));
 }
 
 

--- a/test/base/GroupTest.cpp
+++ b/test/base/GroupTest.cpp
@@ -1,15 +1,22 @@
 #include "BoostUnitTest.h"
 #include "base/Group.h"
+#include "base/UniqueId.h"
 
 #include <iostream>
 
 using namespace NuTo;
 
+struct FooBase : NuTo::UniqueId<FooBase>
+{
+};
+struct Foo : FooBase
+{
+};
 
 BOOST_AUTO_TEST_CASE(ContainsTest)
 {
-    Groups::Group<int> group;
-    int a = 0;
+    Groups::Group<Foo> group;
+    Foo a;
     BOOST_CHECK(not group.Contains(a));
     group.AddMember(a);
     BOOST_CHECK(group.Contains(a));
@@ -17,9 +24,6 @@ BOOST_AUTO_TEST_CASE(ContainsTest)
     BOOST_CHECK(group.Contains(a));
 }
 
-class Foo
-{
-};
 
 struct GroupTestFixture
 {

--- a/test/base/GroupTest.cpp
+++ b/test/base/GroupTest.cpp
@@ -18,9 +18,9 @@ BOOST_AUTO_TEST_CASE(ContainsTest)
     Groups::Group<Foo> group;
     Foo a;
     BOOST_CHECK(not group.Contains(a));
-    group.AddMember(a);
+    group.Add(a);
     BOOST_CHECK(group.Contains(a));
-    group.AddMember(a);
+    group.Add(a);
     BOOST_CHECK(group.Contains(a));
 }
 
@@ -29,14 +29,14 @@ struct GroupTestFixture
 {
     GroupTestFixture()
     {
-        groupOne.AddMember(a);
-        groupOne.AddMember(b);
-        groupOne.AddMember(c);
-        groupOne.AddMember(a); // duplicate!
+        groupOne.Add(a);
+        groupOne.Add(b);
+        groupOne.Add(c);
+        groupOne.Add(a); // duplicate!
 
-        groupTwo.AddMember(c);
-        groupTwo.AddMember(d);
-        groupTwo.AddMember(d); // duplicate!
+        groupTwo.Add(c);
+        groupTwo.Add(d);
+        groupTwo.Add(d); // duplicate!
     }
 
     Foo a, b, c, d;
@@ -95,11 +95,11 @@ BOOST_AUTO_TEST_CASE(CustomCompare)
     int c = 42;
 
     Groups::Group<int, std::less<int*>> g0;
-    g0.AddMember(a);
-    g0.AddMember(b);
-    g0.AddMember(c);
+    g0.Add(a);
+    g0.Add(b);
+    g0.Add(c);
     Groups::Group<int, std::less<int*>> g1;
-    g1.AddMember(b);
+    g1.Add(b);
 
     auto intersection = Groups::Intersection(g0, g1);
     BOOST_CHECK(intersection.Contains(b));

--- a/test/base/GroupTest.cpp
+++ b/test/base/GroupTest.cpp
@@ -47,7 +47,7 @@ struct GroupTestFixture
 
 BOOST_FIXTURE_TEST_CASE(unionTest, GroupTestFixture)
 {
-    auto unionGroup = Groups::Unite(groupOne, groupTwo);
+    auto unionGroup = Groups::Utils::Unite(groupOne, groupTwo);
     BOOST_CHECK_EQUAL(unionGroup.size(), 4);
     BOOST_CHECK(unionGroup.Contains(a));
     BOOST_CHECK(unionGroup.Contains(b));
@@ -58,7 +58,7 @@ BOOST_FIXTURE_TEST_CASE(unionTest, GroupTestFixture)
 
 BOOST_FIXTURE_TEST_CASE(differenceTest, GroupTestFixture)
 {
-    auto diffGroup = Groups::Difference(groupOne, groupTwo);
+    auto diffGroup = Groups::Utils::Difference(groupOne, groupTwo);
     BOOST_CHECK_EQUAL(diffGroup.size(), 2);
     BOOST_CHECK(diffGroup.Contains(a));
     BOOST_CHECK(diffGroup.Contains(b));
@@ -69,7 +69,7 @@ BOOST_FIXTURE_TEST_CASE(differenceTest, GroupTestFixture)
 
 BOOST_FIXTURE_TEST_CASE(intersectionTest, GroupTestFixture)
 {
-    auto intersectGroup = Groups::Intersection(groupOne, groupTwo);
+    auto intersectGroup = Groups::Utils::Intersection(groupOne, groupTwo);
     BOOST_CHECK_EQUAL(intersectGroup.size(), 1);
     BOOST_CHECK(not intersectGroup.Contains(a));
     BOOST_CHECK(not intersectGroup.Contains(b));
@@ -80,7 +80,7 @@ BOOST_FIXTURE_TEST_CASE(intersectionTest, GroupTestFixture)
 
 BOOST_FIXTURE_TEST_CASE(symmetricDiffTest, GroupTestFixture)
 {
-    auto symmetricDiffGroup = Groups::SymmetricDifference(groupOne, groupTwo);
+    auto symmetricDiffGroup = Groups::Utils::SymmetricDifference(groupOne, groupTwo);
     BOOST_CHECK_EQUAL(symmetricDiffGroup.size(), 3);
     BOOST_CHECK(symmetricDiffGroup.Contains(a));
     BOOST_CHECK(symmetricDiffGroup.Contains(b));
@@ -101,6 +101,6 @@ BOOST_AUTO_TEST_CASE(CustomCompare)
     Groups::Group<int, std::less<const int*>> g1;
     g1.Add(b);
 
-    auto intersection = Groups::Intersection(g0, g1);
+    auto intersection = Groups::Utils::Intersection(g0, g1);
     BOOST_CHECK(intersection.Contains(b));
 }

--- a/test/base/GroupTest.cpp
+++ b/test/base/GroupTest.cpp
@@ -48,7 +48,7 @@ struct GroupTestFixture
 BOOST_FIXTURE_TEST_CASE(unionTest, GroupTestFixture)
 {
     auto unionGroup = Groups::Utils::Unite(groupOne, groupTwo);
-    BOOST_CHECK_EQUAL(unionGroup.size(), 4);
+    BOOST_CHECK_EQUAL(unionGroup.Size(), 4);
     BOOST_CHECK(unionGroup.Contains(a));
     BOOST_CHECK(unionGroup.Contains(b));
     BOOST_CHECK(unionGroup.Contains(c));
@@ -59,7 +59,7 @@ BOOST_FIXTURE_TEST_CASE(unionTest, GroupTestFixture)
 BOOST_FIXTURE_TEST_CASE(differenceTest, GroupTestFixture)
 {
     auto diffGroup = Groups::Utils::Difference(groupOne, groupTwo);
-    BOOST_CHECK_EQUAL(diffGroup.size(), 2);
+    BOOST_CHECK_EQUAL(diffGroup.Size(), 2);
     BOOST_CHECK(diffGroup.Contains(a));
     BOOST_CHECK(diffGroup.Contains(b));
     BOOST_CHECK(not diffGroup.Contains(c));
@@ -70,7 +70,7 @@ BOOST_FIXTURE_TEST_CASE(differenceTest, GroupTestFixture)
 BOOST_FIXTURE_TEST_CASE(intersectionTest, GroupTestFixture)
 {
     auto intersectGroup = Groups::Utils::Intersection(groupOne, groupTwo);
-    BOOST_CHECK_EQUAL(intersectGroup.size(), 1);
+    BOOST_CHECK_EQUAL(intersectGroup.Size(), 1);
     BOOST_CHECK(not intersectGroup.Contains(a));
     BOOST_CHECK(not intersectGroup.Contains(b));
     BOOST_CHECK(intersectGroup.Contains(c));
@@ -81,7 +81,7 @@ BOOST_FIXTURE_TEST_CASE(intersectionTest, GroupTestFixture)
 BOOST_FIXTURE_TEST_CASE(symmetricDiffTest, GroupTestFixture)
 {
     auto symmetricDiffGroup = Groups::Utils::SymmetricDifference(groupOne, groupTwo);
-    BOOST_CHECK_EQUAL(symmetricDiffGroup.size(), 3);
+    BOOST_CHECK_EQUAL(symmetricDiffGroup.Size(), 3);
     BOOST_CHECK(symmetricDiffGroup.Contains(a));
     BOOST_CHECK(symmetricDiffGroup.Contains(b));
     BOOST_CHECK(not symmetricDiffGroup.Contains(c));
@@ -118,5 +118,5 @@ BOOST_AUTO_TEST_CASE(GroupCtors)
     BOOST_CHECK(many.Contains(a));
     BOOST_CHECK(many.Contains(b));
     BOOST_CHECK(many.Contains(c));
-    BOOST_CHECK_EQUAL(many.size(), 3);
+    BOOST_CHECK_EQUAL(many.Size(), 3);
 }

--- a/test/base/GroupTest.cpp
+++ b/test/base/GroupTest.cpp
@@ -62,6 +62,8 @@ BOOST_FIXTURE_TEST_CASE(differenceTest, GroupTestFixture)
     BOOST_CHECK_EQUAL(diffGroup.size(), 2);
     BOOST_CHECK(diffGroup.Contains(a));
     BOOST_CHECK(diffGroup.Contains(b));
+    BOOST_CHECK(not diffGroup.Contains(c));
+    BOOST_CHECK(not diffGroup.Contains(d));
 }
 
 
@@ -69,7 +71,10 @@ BOOST_FIXTURE_TEST_CASE(intersectionTest, GroupTestFixture)
 {
     auto intersectGroup = Groups::Intersection(groupOne, groupTwo);
     BOOST_CHECK_EQUAL(intersectGroup.size(), 1);
+    BOOST_CHECK(not intersectGroup.Contains(a));
+    BOOST_CHECK(not intersectGroup.Contains(b));
     BOOST_CHECK(intersectGroup.Contains(c));
+    BOOST_CHECK(not intersectGroup.Contains(d));
 }
 
 
@@ -79,5 +84,23 @@ BOOST_FIXTURE_TEST_CASE(symmetricDiffTest, GroupTestFixture)
     BOOST_CHECK_EQUAL(symmetricDiffGroup.size(), 3);
     BOOST_CHECK(symmetricDiffGroup.Contains(a));
     BOOST_CHECK(symmetricDiffGroup.Contains(b));
+    BOOST_CHECK(not symmetricDiffGroup.Contains(c));
     BOOST_CHECK(symmetricDiffGroup.Contains(d));
+}
+
+BOOST_AUTO_TEST_CASE(CustomCompare)
+{
+    int a = 0;
+    int b = 6174;
+    int c = 42;
+
+    Groups::Group<int, std::less<int*>> g0;
+    g0.AddMember(a);
+    g0.AddMember(b);
+    g0.AddMember(c);
+    Groups::Group<int, std::less<int*>> g1;
+    g1.AddMember(b);
+
+    auto intersection = Groups::Intersection(g0, g1);
+    BOOST_CHECK(intersection.Contains(b));
 }

--- a/test/base/GroupTest.cpp
+++ b/test/base/GroupTest.cpp
@@ -1,0 +1,77 @@
+#include "BoostUnitTest.h"
+#include "base/Group.h"
+
+#include <iostream>
+
+using namespace NuTo;
+
+
+BOOST_AUTO_TEST_CASE(ContainsTest)
+{
+    Groups::Group<int> group;
+    int a = 0;
+    BOOST_CHECK(not group.Contains(a));
+    group.AddMember(a);
+    BOOST_CHECK(group.Contains(a));
+    group.AddMember(a);
+    BOOST_CHECK(group.Contains(a));
+}
+
+class Foo
+{
+};
+
+struct GroupTestFixture
+{
+    GroupTestFixture()
+    {
+        groupOne.AddMember(a);
+        groupOne.AddMember(b);
+        groupOne.AddMember(c);
+
+        groupTwo.AddMember(c);
+        groupTwo.AddMember(d);
+    }
+
+    Foo a, b, c, d;
+
+    Groups::Group<Foo> groupOne;
+    Groups::Group<Foo> groupTwo;
+};
+
+BOOST_FIXTURE_TEST_CASE(unionTest, GroupTestFixture)
+{
+    auto unionGroup = Groups::Unite(groupOne, groupTwo);
+    BOOST_CHECK_EQUAL(unionGroup.size(), 4);
+    BOOST_CHECK(unionGroup.Contains(a));
+    BOOST_CHECK(unionGroup.Contains(b));
+    BOOST_CHECK(unionGroup.Contains(c));
+    BOOST_CHECK(unionGroup.Contains(d));
+}
+
+
+BOOST_FIXTURE_TEST_CASE(differenceTest, GroupTestFixture)
+{
+    auto diffGroup = Groups::Difference(groupOne, groupTwo);
+    BOOST_CHECK_EQUAL(diffGroup.size(), 2);
+    BOOST_CHECK(diffGroup.Contains(a));
+    BOOST_CHECK(diffGroup.Contains(b));
+}
+
+
+BOOST_FIXTURE_TEST_CASE(intersectionTest, GroupTestFixture)
+{
+    auto intersectGroup = Groups::Intersection(groupOne, groupTwo);
+    BOOST_CHECK_EQUAL(intersectGroup.size(), 1);
+    BOOST_CHECK(intersectGroup.Contains(c));
+}
+
+
+BOOST_FIXTURE_TEST_CASE(symmetricDiffTest, GroupTestFixture)
+{
+    auto symmetricDiffGroup = Groups::SymmetricDifference(groupOne, groupTwo);
+    BOOST_CHECK_EQUAL(symmetricDiffGroup.size(), 3);
+    BOOST_CHECK(symmetricDiffGroup.Contains(a));
+    BOOST_CHECK(symmetricDiffGroup.Contains(b));
+    BOOST_CHECK(symmetricDiffGroup.Contains(d));
+}

--- a/test/base/GroupTest.cpp
+++ b/test/base/GroupTest.cpp
@@ -47,7 +47,7 @@ struct GroupTestFixture
 
 BOOST_FIXTURE_TEST_CASE(unionTest, GroupTestFixture)
 {
-    auto unionGroup = Groups::Utils::Unite(groupOne, groupTwo);
+    auto unionGroup = Groups::Unite(groupOne, groupTwo);
     BOOST_CHECK_EQUAL(unionGroup.Size(), 4);
     BOOST_CHECK(unionGroup.Contains(a));
     BOOST_CHECK(unionGroup.Contains(b));
@@ -58,7 +58,7 @@ BOOST_FIXTURE_TEST_CASE(unionTest, GroupTestFixture)
 
 BOOST_FIXTURE_TEST_CASE(differenceTest, GroupTestFixture)
 {
-    auto diffGroup = Groups::Utils::Difference(groupOne, groupTwo);
+    auto diffGroup = Groups::Difference(groupOne, groupTwo);
     BOOST_CHECK_EQUAL(diffGroup.Size(), 2);
     BOOST_CHECK(diffGroup.Contains(a));
     BOOST_CHECK(diffGroup.Contains(b));
@@ -69,7 +69,7 @@ BOOST_FIXTURE_TEST_CASE(differenceTest, GroupTestFixture)
 
 BOOST_FIXTURE_TEST_CASE(intersectionTest, GroupTestFixture)
 {
-    auto intersectGroup = Groups::Utils::Intersection(groupOne, groupTwo);
+    auto intersectGroup = Groups::Intersection(groupOne, groupTwo);
     BOOST_CHECK_EQUAL(intersectGroup.Size(), 1);
     BOOST_CHECK(not intersectGroup.Contains(a));
     BOOST_CHECK(not intersectGroup.Contains(b));
@@ -80,7 +80,7 @@ BOOST_FIXTURE_TEST_CASE(intersectionTest, GroupTestFixture)
 
 BOOST_FIXTURE_TEST_CASE(symmetricDiffTest, GroupTestFixture)
 {
-    auto symmetricDiffGroup = Groups::Utils::SymmetricDifference(groupOne, groupTwo);
+    auto symmetricDiffGroup = Groups::SymmetricDifference(groupOne, groupTwo);
     BOOST_CHECK_EQUAL(symmetricDiffGroup.Size(), 3);
     BOOST_CHECK(symmetricDiffGroup.Contains(a));
     BOOST_CHECK(symmetricDiffGroup.Contains(b));
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(CustomCompare)
     Groups::Group<int, std::less<const int*>> g1;
     g1.Add(b);
 
-    auto intersection = Groups::Utils::Intersection(g0, g1);
+    auto intersection = Groups::Intersection(g0, g1);
     BOOST_CHECK(intersection.Contains(b));
 }
 


### PR DESCRIPTION
Add group as proposed in #63. And this group is handy for the next steps in the PDE implementation. So I just added it. 

Anyways, in #63 we discussed the behavior concerning duplicates. 

6748a06 adds the group as it is in the gist, based on std::vector, allowing duplicates.
Can you think of cases where multiple same entries in a group make sense? IMO it is reasonable to ignore duplicates. 

Thus, the current version uses a std::set. This automatically ignores duplicates but loses the ordering. As @joergfunger mentioned, this could cause problems in tests that rely on an order. One example, he thought of (and I hope I understood correctly), are constraint equations that are defined as follows. First, select nodes and put them in our group. Second, pick _some_ node (say `Group::begin()`) from that group and define it as the active dof. Third, define constraint equations, connecting all remaining group entries with the active dof. Last, test some global result vector. So depending on `Group::begin()` - that may change from one run to another (Group [= std::set] is now sorted by pointer addresses) - the active/dependent dofs and thus the result vector changes. This test could easily be rewritten to avoid this problem by manually picking the active dof by e.g. its coordinate. By maybe I misunderstood the issue or you can think of other cases where order matters. 

So what do you think?