### PR TITLE
PDE_ids

### DIFF
--- a/src/base/UniqueId.h
+++ b/src/base/UniqueId.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace NuTo
+{
+//! @brief This class provides a unique id (beginning at 0 and incrementing for each object).
+//! @tparam T Without the template, the id would be unique for all classes. Say, 1000 nodes are created first and get
+//! the ids 0...999. Element ids would then start at 1000. With this template, T=Node or T=Element, each T starts at 0
+//! again.
+template <typename T>
+class UniqueId
+{
+public:
+    UniqueId()
+        : mId(mIdCounter++)
+    {
+    }
+
+    int Id() const
+    {
+        return mId;
+    }
+
+private:
+    int mId;
+    static int mIdCounter;
+};
+
+template <typename T>
+int UniqueId<T>::mIdCounter = 0;
+
+} /* NuTo */

--- a/test/base/CMakeLists.txt
+++ b/test/base/CMakeLists.txt
@@ -1,1 +1,3 @@
+add_unit_test(UniqueId)
 add_subdirectory(serializeStream)
+

--- a/test/base/UniqueId.cpp
+++ b/test/base/UniqueId.cpp
@@ -13,7 +13,8 @@ BOOST_AUTO_TEST_CASE(IdsCreate)
 
 BOOST_AUTO_TEST_CASE(IdsCopyMove)
 {
-    struct Foo : NuTo::UniqueId<Foo> {};
+    struct FooBase : NuTo::UniqueId<FooBase> {};
+    struct Foo : FooBase {};
     Foo foo;
     int id = foo.Id();
     Foo fooCopyCtor(foo); // copy ctor

--- a/test/base/UniqueId.cpp
+++ b/test/base/UniqueId.cpp
@@ -1,0 +1,35 @@
+#include "BoostUnitTest.h"
+#include "base/UniqueId.h"
+
+BOOST_AUTO_TEST_CASE(IdsCreate)
+{
+    struct Foo : NuTo::UniqueId<Foo> {};
+    for (int i = 0; i < 10; ++i)
+        BOOST_CHECK_EQUAL(Foo().Id(), i);
+    struct Bar : NuTo::UniqueId<Bar> {};
+    for (int i = 0; i < 10; ++i)
+        BOOST_CHECK_EQUAL(Bar().Id(), i);
+}
+
+BOOST_AUTO_TEST_CASE(IdsCopyMove)
+{
+    struct Foo : NuTo::UniqueId<Foo> {};
+    Foo foo;
+    int id = foo.Id();
+    Foo fooCopyCtor(foo); // copy ctor
+    BOOST_CHECK_EQUAL(fooCopyCtor.Id(), id);
+
+    Foo fooCopyAssign; // should create a new unique id
+    BOOST_CHECK(fooCopyAssign.Id() != id);
+
+    fooCopyAssign = foo; // copy assign copies the id
+    BOOST_CHECK_EQUAL(fooCopyAssign.Id(), id);
+
+    Foo fooMoveCtor(std::move(foo));
+    BOOST_CHECK_EQUAL(fooMoveCtor.Id(), id);
+    
+    Foo fooMoveAssign;
+    BOOST_CHECK(fooMoveAssign.Id() != id);
+    fooMoveAssign = std::move(fooMoveCtor); // foo is invalid after move 
+    BOOST_CHECK_EQUAL(fooMoveAssign.Id(), id);
+}


### PR DESCRIPTION
Really quick implementation of a trivial static counted id class. 

Obtain a unique id for your class `Foo` by deriving from `NuTo::UniqueId<Foo>´. The ids start at 0 and are incremented at each object instantiation. The template argument provides a new numbering (starting at 0) for each template argument.

Without template:
~~~c++
struct Foo : UniqueId {};
struct Bar : UniqueId {};

Foo f0; // 0;
Foo f1; // 1;
Bar b0; // 2;
Foo f2; // 3;
bar b1; // 4;
~~~

With template:
~~~c++
struct Foo : UniqueId<Foo> {};
struct Bar : UniqueId<Bar> {};

Foo f0; // 0;
Foo f1; // 1;
Bar b0; // 0;
Foo f2; // 2;
bar b1; // 1;
~~~
