### PR TITLE
Pde renaming to Element

### DIFF
--- a/src/mechanics/cell/Cell.h
+++ b/src/mechanics/cell/Cell.h
@@ -2,7 +2,7 @@
 
 #include "mechanics/cell/CellInterface.h"
 #include <boost/ptr_container/ptr_vector.hpp>
-#include "mechanics/interpolation/CellInterpolationBase.h"
+#include "mechanics/elements/ElementInterface.h"
 #include "mechanics/nodes/DofContainer.h"
 #include "mechanics/cell/Integrand.h"
 #include "mechanics/integrationtypes/IntegrationTypeBase.h"
@@ -13,7 +13,7 @@ template <int TDim>
 class Cell : public CellInterface
 {
 public:
-    Cell(const CellInterpolationBase& coordinateInterpolation, DofContainer<CellInterpolationBase*> cellinterpolation,
+    Cell(const ElementInterface& coordinateInterpolation, DofContainer<ElementInterface*> cellinterpolation,
          const IntegrationTypeBase& integrationType, const Integrand<TDim>& integrand)
         : mCoordinateInterpolation(coordinateInterpolation)
         , mCellInterpolation(cellinterpolation)
@@ -82,8 +82,8 @@ public:
     }
 
 private:
-    const CellInterpolationBase& mCoordinateInterpolation;
-    DofContainer<CellInterpolationBase*> mCellInterpolation;
+    const ElementInterface& mCoordinateInterpolation;
+    DofContainer<ElementInterface*> mCellInterpolation;
     const IntegrationTypeBase& mIntegrationType;
     boost::ptr_vector<Integrand<TDim>> mIntegrand;
 };

--- a/src/mechanics/cell/CellData.h
+++ b/src/mechanics/cell/CellData.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "mechanics/interpolation/CellInterpolationBase.h"
+#include "mechanics/elements/ElementInterface.h"
 #include "mechanics/nodes/DofContainer.h"
 
 namespace NuTo
@@ -14,7 +14,7 @@ namespace NuTo
 class CellData
 {
 public:
-    CellData(const DofContainer<CellInterpolationBase*>& elements)
+    CellData(const DofContainer<ElementInterface*>& elements)
         : mElements(elements)
     {
     }
@@ -34,6 +34,6 @@ public:
 
 private:
     mutable DofContainer<NodeValues> mNodeValues;
-    const DofContainer<CellInterpolationBase*>& mElements;
+    const DofContainer<ElementInterface*>& mElements;
 };
 } /* NuTo */

--- a/src/mechanics/cell/CellIpData.h
+++ b/src/mechanics/cell/CellIpData.h
@@ -13,9 +13,9 @@ template <int TDim>
 class CellIpData
 {
 public:
-    CellIpData(const DofContainer<ElementInterface*> cellInterpolation, const NuTo::Jacobian<TDim>& jacobian,
+    CellIpData(const DofContainer<ElementInterface*> elements, const NuTo::Jacobian<TDim>& jacobian,
                const NaturalCoords& ipCoords)
-        : mCellInterpolation(cellInterpolation)
+        : mElements(elements)
         , mJacobian(jacobian)
         , mIPCoords(ipCoords)
     {
@@ -23,7 +23,7 @@ public:
 
     NMatrix GetNMatrix(const DofType& dofType) const
     {
-        return mCellInterpolation[dofType]->GetNMatrix(mIPCoords);
+        return mElements[dofType]->GetNMatrix(mIPCoords);
     }
 
     BMatrixGradient GetBMatrixGradient(const DofType& dofType) const
@@ -105,11 +105,11 @@ private:
     DerivativeShapeFunctionsGlobal CalculateDerivativeShapeFunctionsGlobal(const DofType& dofType) const
     {
         DerivativeShapeFunctionsNatural dShapeNatural =
-                mCellInterpolation[dofType]->GetDerivativeShapeFunctions(mIPCoords);
+                mElements[dofType]->GetDerivativeShapeFunctions(mIPCoords);
         return mJacobian.TransformDerivativeShapeFunctions(dShapeNatural);
     }
 
-    const DofContainer<ElementInterface*> mCellInterpolation;
+    const DofContainer<ElementInterface*> mElements;
     const NuTo::Jacobian<TDim>& mJacobian;
     const NaturalCoords& mIPCoords;
 };

--- a/src/mechanics/cell/CellIpData.h
+++ b/src/mechanics/cell/CellIpData.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "mechanics/interpolation/CellInterpolationBase.h"
+#include "mechanics/elements/ElementInterface.h"
 #include "mechanics/nodes/DofContainer.h"
 #include "mechanics/cell/Jacobian.h"
 
@@ -13,7 +13,7 @@ template <int TDim>
 class CellIpData
 {
 public:
-    CellIpData(const DofContainer<CellInterpolationBase*> cellInterpolation, const NuTo::Jacobian<TDim>& jacobian,
+    CellIpData(const DofContainer<ElementInterface*> cellInterpolation, const NuTo::Jacobian<TDim>& jacobian,
                const NaturalCoords& ipCoords)
         : mCellInterpolation(cellInterpolation)
         , mJacobian(jacobian)
@@ -109,7 +109,7 @@ private:
         return mJacobian.TransformDerivativeShapeFunctions(dShapeNatural);
     }
 
-    const DofContainer<CellInterpolationBase*> mCellInterpolation;
+    const DofContainer<ElementInterface*> mCellInterpolation;
     const NuTo::Jacobian<TDim>& mJacobian;
     const NaturalCoords& mIPCoords;
 };

--- a/src/mechanics/elements/ElementFem.h
+++ b/src/mechanics/elements/ElementFem.h
@@ -2,17 +2,17 @@
 
 #include <vector>
 #include "mechanics/nodes/NodeSimple.h"
-#include "mechanics/interpolation/CellInterpolationBase.h"
+#include "mechanics/elements/ElementInterface.h"
 #include "mechanics/interpolation/InterpolationSimple.h"
 #include "mechanics/cell/Matrix.h"
 
 namespace NuTo
 {
 
-class CellInterpolationFem : public CellInterpolationBase
+class ElementFem : public ElementInterface
 {
 public:
-    CellInterpolationFem(std::vector<NuTo::NodeSimple*> nodes, const InterpolationSimple& interpolation)
+    ElementFem(std::vector<NuTo::NodeSimple*> nodes, const InterpolationSimple& interpolation)
         : mNodes(nodes)
         , mInterpolation(interpolation)
     {

--- a/src/mechanics/elements/ElementIga.h
+++ b/src/mechanics/elements/ElementIga.h
@@ -2,17 +2,17 @@
 
 #include <vector>
 #include "mechanics/nodes/NodeSimple.h"
-#include "CellInterpolationBase.h"
+#include "mechanics/elements/ElementInterface.h"
 #include "mechanics/iga/Nurbs.h"
 #include "mechanics/cell/Matrix.h"
 
 namespace NuTo
 {
 template <int TDimParameter>
-class CellInterpolationIga : public CellInterpolationBase
+class ElementIga : public ElementInterface
 {
 public:
-    CellInterpolationIga(const std::array<int, TDimParameter>& knotIDs, const Nurbs<TDimParameter>& NurbsGeometry)
+    ElementIga(const std::array<int, TDimParameter>& knotIDs, const Nurbs<TDimParameter>& NurbsGeometry)
         : mKnotIDs(knotIDs)
         , mNurbsGeometry(NurbsGeometry)
     {

--- a/src/mechanics/elements/ElementInterface.h
+++ b/src/mechanics/elements/ElementInterface.h
@@ -1,14 +1,14 @@
 #pragma once
 #include <eigen3/Eigen/Dense>
-#include "TypeDefs.h"
+#include "mechanics/interpolation/TypeDefs.h"
 
 namespace NuTo
 {
 
-class CellInterpolationBase
+class ElementInterface
 {
 public:
-    virtual ~CellInterpolationBase() = default;
+    virtual ~ElementInterface() = default;
 
     //! @brief extracts all node values of this element
     virtual NodeValues ExtractNodeValues() const = 0;

--- a/src/mechanics/interpolation/InterpolationQuadLinear.h
+++ b/src/mechanics/interpolation/InterpolationQuadLinear.h
@@ -7,8 +7,8 @@ namespace NuTo
 class InterpolationQuadLinear : public InterpolationSimple
 {
 public:
-    InterpolationQuadLinear(int rDofDimension)
-        : mDofDimension(rDofDimension)
+    InterpolationQuadLinear(int dofDimension)
+        : mDofDimension(dofDimension)
     {
     }
 
@@ -17,19 +17,19 @@ public:
         return std::make_unique<InterpolationQuadLinear>(*this);
     }
 
-    ShapeFunctions GetShapeFunctions(const NaturalCoords& rNaturalIPCoords) const override
+    ShapeFunctions GetShapeFunctions(const NaturalCoords& naturalIpCoords) const override
     {
-        return ShapeFunctions2D::ShapeFunctionsQuadOrder1(rNaturalIPCoords);
+        return ShapeFunctions2D::ShapeFunctionsQuadOrder1(naturalIpCoords);
     }
 
-    DerivativeShapeFunctionsNatural GetDerivativeShapeFunctions(const NaturalCoords& rNaturalIPCoords) const override
+    DerivativeShapeFunctionsNatural GetDerivativeShapeFunctions(const NaturalCoords& naturalIpCoords) const override
     {
-        return ShapeFunctions2D::DerivativeShapeFunctionsQuadOrder1(rNaturalIPCoords);
+        return ShapeFunctions2D::DerivativeShapeFunctionsQuadOrder1(naturalIpCoords);
     }
 
-    NaturalCoords GetLocalCoords(int rNodeId) const override
+    NaturalCoords GetLocalCoords(int nodeId) const override
     {
-        return ShapeFunctions2D::NodeCoordinatesQuadOrder1(rNodeId);
+        return ShapeFunctions2D::NodeCoordinatesQuadOrder1(nodeId);
     }
 
     int GetNumNodes() const override

--- a/src/mechanics/interpolation/InterpolationQuadSerendipity.h
+++ b/src/mechanics/interpolation/InterpolationQuadSerendipity.h
@@ -7,8 +7,8 @@ namespace NuTo
 class InterpolationQuadSerendipity : public InterpolationSimple
 {
 public:
-    InterpolationQuadSerendipity(int rDofDimension)
-        : mDofDimension(rDofDimension)
+    InterpolationQuadSerendipity(int dofDimension)
+        : mDofDimension(dofDimension)
     {
     }
 
@@ -17,19 +17,19 @@ public:
         return std::make_unique<InterpolationQuadSerendipity>(*this);
     }
 
-    ShapeFunctions GetShapeFunctions(const NaturalCoords& rNaturalIPCoords) const override
+    ShapeFunctions GetShapeFunctions(const NaturalCoords& naturalIpCoords) const override
     {
-        return ShapeFunctions2D::ShapeFunctionsQuadOrder2(rNaturalIPCoords);
+        return ShapeFunctions2D::ShapeFunctionsQuadOrder2(naturalIpCoords);
     }
 
-    DerivativeShapeFunctionsNatural GetDerivativeShapeFunctions(const NaturalCoords& rNaturalIPCoords) const override
+    DerivativeShapeFunctionsNatural GetDerivativeShapeFunctions(const NaturalCoords& naturalIpCoords) const override
     {
-        return ShapeFunctions2D::DerivativeShapeFunctionsQuadOrder2(rNaturalIPCoords);
+        return ShapeFunctions2D::DerivativeShapeFunctionsQuadOrder2(naturalIpCoords);
     }
 
-    NaturalCoords GetLocalCoords(int rNodeId) const override
+    NaturalCoords GetLocalCoords(int nodeId) const override
     {
-        return ShapeFunctions2D::NodeCoordinatesQuadOrder2(rNodeId);
+        return ShapeFunctions2D::NodeCoordinatesQuadOrder2(nodeId);
     }
 
     int GetNumNodes() const override

--- a/src/mechanics/interpolation/InterpolationSimple.h
+++ b/src/mechanics/interpolation/InterpolationSimple.h
@@ -11,31 +11,25 @@ namespace NuTo
 class InterpolationSimple
 {
 public:
-    InterpolationSimple() = default;
     virtual ~InterpolationSimple() = default; // virtual destructor needed, rule of 5 below...
-    InterpolationSimple(const InterpolationSimple&) = default;
-    InterpolationSimple(InterpolationSimple&&) = default;
-    InterpolationSimple& operator=(const InterpolationSimple&) = default;
-    InterpolationSimple& operator=(InterpolationSimple&&) = default;
 
     virtual std::unique_ptr<InterpolationSimple> Clone() const = 0;
 
     //! @brief calculates the shape functions
-    //! @param rNaturalIPCoords integration point coordinates in the natural coordinate system
+    //! @param naturalIpCoords integration point coordinates in the natural coordinate system
     //! @return vector of shape functions, dimension: [GetNumNodes() x 1]
-    virtual ShapeFunctions GetShapeFunctions(const NaturalCoords& rNaturalIPCoords) const = 0;
+    virtual ShapeFunctions GetShapeFunctions(const NaturalCoords& naturalIpCoords) const = 0;
 
     //! @brief calculates the derivative shape functions
     //! @param rNaturalPCoords integration point coordinates in the natural coordinate system
     //! @return matrix of derivate shape functions, dimension: [GetNumNodes() x local dimension]
     //! @remark 'local dimension' above is the dimension of rLocalIPCoords
-    virtual DerivativeShapeFunctionsNatural
-    GetDerivativeShapeFunctions(const NaturalCoords& rNaturalIPCoords) const = 0;
+    virtual DerivativeShapeFunctionsNatural GetDerivativeShapeFunctions(const NaturalCoords& naturalIpCoords) const = 0;
 
     //! @brief returns the local node coordinates
-    //! @param rNodeId local node number
+    //! @param nodeId local node number
     //! @return node coordinates in the natural coordinate system
-    virtual NaturalCoords GetLocalCoords(int rNodeId) const = 0;
+    virtual NaturalCoords GetLocalCoords(int nodeId) const = 0;
 
     //! @brief returns the number of nodes
     //! @return number of nodes
@@ -45,11 +39,11 @@ public:
 };
 
 //! @brief clone methods that enables a boost::ptr_container<this> to copy itself
-//! @param rLaw reference to the IPConstitutiveLawBase
-//! @return cloned owning raw pointer of rLaw
-inline NuTo::InterpolationSimple* new_clone(const NuTo::InterpolationSimple& rInterpolation)
+//! @param interpolation reference to the InterpolationSimple
+//! @return cloned owning raw pointer of interpolation
+inline NuTo::InterpolationSimple* new_clone(const NuTo::InterpolationSimple& interpolation)
 {
-    return rInterpolation.Clone().release();
+    return interpolation.Clone().release();
 }
 
 } /* NuTo */

--- a/src/mechanics/interpolation/InterpolationTriangleLinear.h
+++ b/src/mechanics/interpolation/InterpolationTriangleLinear.h
@@ -8,8 +8,8 @@ namespace NuTo
 class InterpolationTriangleLinear : public InterpolationSimple
 {
 public:
-    InterpolationTriangleLinear(int rDofDimension)
-        : mDofDimension(rDofDimension)
+    InterpolationTriangleLinear(int dofDimension)
+        : mDofDimension(dofDimension)
     {
     }
 
@@ -18,19 +18,19 @@ public:
         return std::make_unique<InterpolationTriangleLinear>(*this);
     }
 
-    ShapeFunctions GetShapeFunctions(const NaturalCoords& rNaturalIPCoords) const override
+    ShapeFunctions GetShapeFunctions(const NaturalCoords& naturalIpCoords) const override
     {
-        return ShapeFunctions2D::ShapeFunctionsTriangleOrder1(rNaturalIPCoords);
+        return ShapeFunctions2D::ShapeFunctionsTriangleOrder1(naturalIpCoords);
     }
 
-    DerivativeShapeFunctionsNatural GetDerivativeShapeFunctions(const NaturalCoords& rNaturalIPCoords) const override
+    DerivativeShapeFunctionsNatural GetDerivativeShapeFunctions(const NaturalCoords& naturalIpCoords) const override
     {
-        return ShapeFunctions2D::DerivativeShapeFunctionsTriangleOrder1(rNaturalIPCoords);
+        return ShapeFunctions2D::DerivativeShapeFunctionsTriangleOrder1(naturalIpCoords);
     }
 
-    NaturalCoords GetLocalCoords(int rNodeId) const override
+    NaturalCoords GetLocalCoords(int nodeId) const override
     {
-        return ShapeFunctions2D::NodeCoordinatesTriangleOrder1(rNodeId);
+        return ShapeFunctions2D::NodeCoordinatesTriangleOrder1(nodeId);
     }
 
     int GetNumNodes() const override

--- a/src/mechanics/mesh/Mesh.h
+++ b/src/mechanics/mesh/Mesh.h
@@ -1,8 +1,7 @@
 #pragma once
 #include <boost/ptr_container/ptr_vector.hpp>
-#include "mechanics/interpolation/CellInterpolationBase.h"
 #include "mechanics/nodes/NodeSimple.h"
-#include "mechanics/interpolation/CellInterpolationFem.h"
+#include "mechanics/elements/ElementFem.h"
 
 namespace NuTo
 {
@@ -10,27 +9,27 @@ class Mesh
 {
 public:
 
-    NodeSimple& CreateNode(Eigen::VectorXd rValues)
+    NodeSimple& CreateNode(Eigen::VectorXd values)
     {
-        mNodes.push_back(new NodeSimple(rValues));
+        mNodes.push_back(new NodeSimple(values));
         return *mNodes.rbegin();
     }
 
-    CellInterpolationBase& CreateElement(std::vector<NodeSimple*> rNodes, const InterpolationSimple& rInterpolation)
+    ElementInterface& CreateElement(std::vector<NodeSimple*> nodes, const InterpolationSimple& interpolation)
     {
-        mElements.push_back(new CellInterpolationFem{rNodes, rInterpolation});
+        mElements.push_back(new ElementFem{nodes, interpolation});
         return *mElements.rbegin();
     }
 
-    InterpolationSimple& CreateInterpolation(const InterpolationSimple& rInterpolation)
+    InterpolationSimple& CreateInterpolation(const InterpolationSimple& interpolation)
     {
-        mInterpolations.push_back(rInterpolation.Clone().release());
+        mInterpolations.push_back(interpolation.Clone().release());
         return *mInterpolations.rbegin();
     }
 
 private:
     boost::ptr_vector<InterpolationSimple> mInterpolations;
-    boost::ptr_vector<CellInterpolationFem> mElements;
+    boost::ptr_vector<ElementFem> mElements;
     boost::ptr_vector<NodeSimple> mNodes;
 };
 } /* NuTo */

--- a/test/mechanics/cell/Cell.cpp
+++ b/test/mechanics/cell/Cell.cpp
@@ -1,7 +1,7 @@
 #include "BoostUnitTest.h"
 #include <fakeit.hpp>
 #include "mechanics/cell/Cell.h"
-#include "mechanics/interpolation/CellInterpolationFem.h"
+#include "mechanics/elements/ElementFem.h"
 #include "mechanics/interpolation/InterpolationQuadLinear.h"
 #include "mechanics/integrationtypes/IntegrationTypeTensorProduct.h"
 #include "mechanics/cell/IntegrandLinearElastic.h"
@@ -19,17 +19,17 @@ BOOST_AUTO_TEST_CASE(CellLetsSee)
     NuTo::NodeSimple nCoord1(Eigen::Vector2d({lx, 0}));
     NuTo::NodeSimple nCoord2(Eigen::Vector2d({lx, ly}));
     NuTo::NodeSimple nCoord3(Eigen::Vector2d({0, ly}));
-    NuTo::CellInterpolationFem coordinateElement({&nCoord0, &nCoord1, &nCoord2, &nCoord3}, interpolationCoordinates);
+    NuTo::ElementFem coordinateElement({&nCoord0, &nCoord1, &nCoord2, &nCoord3}, interpolationCoordinates);
 
     NuTo::InterpolationQuadLinear interpolationDisplacements(2);
     NuTo::NodeSimple nDispl0(Eigen::Vector2d({0, 0}));
     NuTo::NodeSimple nDispl1(Eigen::Vector2d({0, 0}));
     NuTo::NodeSimple nDispl2(Eigen::Vector2d({0, 0}));
     NuTo::NodeSimple nDispl3(Eigen::Vector2d({0, 0}));
-    NuTo::CellInterpolationFem displacementElement({&nDispl0, &nDispl1, &nDispl2, &nDispl3}, interpolationDisplacements);
+    NuTo::ElementFem displacementElement({&nDispl0, &nDispl1, &nDispl2, &nDispl3}, interpolationDisplacements);
 
     NuTo::DofType dofDispl("Displacements", 2, 0);
-    NuTo::DofContainer<NuTo::CellInterpolationBase*> elements;
+    NuTo::DofContainer<NuTo::ElementInterface*> elements;
     elements[dofDispl] = &displacementElement;
 
     fakeit::Mock<NuTo::IntegrationTypeBase> intType;

--- a/test/mechanics/cell/CellData.cpp
+++ b/test/mechanics/cell/CellData.cpp
@@ -5,10 +5,10 @@
 
 BOOST_AUTO_TEST_CASE(CacheNodeValues)
 {
-    fakeit::Mock<NuTo::CellInterpolationBase> element;
+    fakeit::Mock<NuTo::ElementInterface> element;
     Method(element, ExtractNodeValues) = Eigen::Vector2d({42, 6174});
     NuTo::DofType dof("dof", 1, 0);
-    NuTo::DofContainer<NuTo::CellInterpolationBase*> elements;
+    NuTo::DofContainer<NuTo::ElementInterface*> elements;
     elements[dof] = &element.get();
 
     NuTo::CellData cell(elements);

--- a/test/mechanics/cell/CellIpData.cpp
+++ b/test/mechanics/cell/CellIpData.cpp
@@ -52,11 +52,11 @@ NuTo::DerivativeShapeFunctionsNatural MockDerivatives3D()
 
 BOOST_AUTO_TEST_CASE(CellIPData2D)
 {
-    fakeit::Mock<NuTo::CellInterpolationBase> interpolation;
+    fakeit::Mock<NuTo::ElementInterface> interpolation;
     Method(interpolation, GetDerivativeShapeFunctions) = MockDerivatives2D();
     NuTo::DofType d0("dof0", 2, 0);
 
-    NuTo::DofContainer<NuTo::CellInterpolationBase*> elements;
+    NuTo::DofContainer<NuTo::ElementInterface*> elements;
     elements[d0] = &interpolation.get();
 
     NuTo::NaturalCoords ipCoords = Eigen::Vector2d({1. / 3., 1. / 3.});
@@ -102,11 +102,11 @@ BOOST_AUTO_TEST_CASE(CellIPData2D)
 
 BOOST_AUTO_TEST_CASE(InterpolationBStrain3D)
 {
-    fakeit::Mock<NuTo::CellInterpolationBase> interpolation;
+    fakeit::Mock<NuTo::ElementInterface> interpolation;
     Method(interpolation, GetDerivativeShapeFunctions) = MockDerivatives3D();
     NuTo::DofType d0("dof0", 3, 0);
 
-    NuTo::DofContainer<NuTo::CellInterpolationBase*> elements;
+    NuTo::DofContainer<NuTo::ElementInterface*> elements;
     elements[d0] = &interpolation.get();
 
     NuTo::NaturalCoords ipCoords = Eigen::Vector3d({1. / 3., 1. / 3., 1. / 3.});

--- a/test/mechanics/elements/CMakeLists.txt
+++ b/test/mechanics/elements/CMakeLists.txt
@@ -19,3 +19,6 @@ add_unit_test(IPData
     mechanics/constitutive/ConstitutiveEnum.cpp
     mechanics/timeIntegration/ImplExCallback.cpp
     )
+
+add_unit_test(ElementIga)
+add_unit_test(ElementFem mechanics/elements/ElementShapeFunctions.cpp)

--- a/test/mechanics/elements/ElementFem.cpp
+++ b/test/mechanics/elements/ElementFem.cpp
@@ -2,21 +2,21 @@
 #include <fakeit.hpp>
 #include <type_traits>
 
-#include "mechanics/interpolation/CellInterpolationFem.h"
+#include "mechanics/elements/ElementFem.h"
 #include "mechanics/interpolation/InterpolationTriangleLinear.h"
 
 
 BOOST_AUTO_TEST_CASE(ElementCopyMove)
 {
-    BOOST_CHECK(std::is_copy_constructible<NuTo::CellInterpolationFem>::value);
-    BOOST_CHECK(std::is_move_constructible<NuTo::CellInterpolationFem>::value);
+    BOOST_CHECK(std::is_copy_constructible<NuTo::ElementFem>::value);
+    BOOST_CHECK(std::is_move_constructible<NuTo::ElementFem>::value);
 }
 
 
-struct TestElement : public NuTo::CellInterpolationFem
+struct TestElement : public NuTo::ElementFem
 {
     TestElement()
-        : NuTo::CellInterpolationFem({&n0, &n1, &n2}, interpolation)
+        : NuTo::ElementFem({&n0, &n1, &n2}, interpolation)
     {
     }
 

--- a/test/mechanics/elements/ElementIga.cpp
+++ b/test/mechanics/elements/ElementIga.cpp
@@ -2,16 +2,15 @@
 #include <boost/test/output_test_stream.hpp>
 #include <type_traits>
 
-#include "mechanics/interpolation/CellInterpolationIga.h"
-#include <iostream>
+#include "mechanics/elements/ElementIga.h"
 
 BOOST_AUTO_TEST_CASE(ElementCopyMove)
 {
-    BOOST_CHECK(std::is_copy_constructible<NuTo::CellInterpolationIga<1>>::value);
-    BOOST_CHECK(std::is_move_constructible<NuTo::CellInterpolationIga<1>>::value);
+    BOOST_CHECK(std::is_copy_constructible<NuTo::ElementIga<1>>::value);
+    BOOST_CHECK(std::is_move_constructible<NuTo::ElementIga<1>>::value);
 
-    BOOST_CHECK(std::is_copy_constructible<NuTo::CellInterpolationIga<2>>::value);
-    BOOST_CHECK(std::is_move_constructible<NuTo::CellInterpolationIga<2>>::value);
+    BOOST_CHECK(std::is_copy_constructible<NuTo::ElementIga<2>>::value);
+    BOOST_CHECK(std::is_move_constructible<NuTo::ElementIga<2>>::value);
 }
 
 
@@ -43,7 +42,7 @@ BOOST_AUTO_TEST_CASE(ExtractNodeValues1D)
     NuTo::Nurbs<1> curve(knots, controlPoints, weights, degree);
 
     std::array<int, 1> knotIDsCell = {4};
-    NuTo::CellInterpolationIga<1> iga(knotIDsCell, curve);
+    NuTo::ElementIga<1> iga(knotIDsCell, curve);
     NuTo::NodeValues nodeValues = iga.ExtractNodeValues();
 
     // ip coordinates are passed in

--- a/test/mechanics/interpolation/CMakeLists.txt
+++ b/test/mechanics/interpolation/CMakeLists.txt
@@ -5,6 +5,3 @@ add_unit_test(InterpolationQuadLinear
 add_unit_test(InterpolationQuadSerendipity
     mechanics/elements/ElementShapeFunctions.cpp)
 
-add_unit_test(CellInterpolationFem mechanics/elements/ElementShapeFunctions.cpp)
-
-add_unit_test(CellInterpolationIga)

--- a/test/mechanics/todo/todoCache.cpp
+++ b/test/mechanics/todo/todoCache.cpp
@@ -5,10 +5,10 @@
 
 BOOST_AUTO_TEST_CASE(CacheNodeValues)
 {
-    fakeit::Mock<NuTo::CellInterpolationBase> element;
+    fakeit::Mock<NuTo::ElementInterface> element;
     Method(element, ExtractNodeValues) = Eigen::Vector2d({42, 6174});
     NuTo::DofType dof("dof", 1, 0);
-    NuTo::DofContainer<NuTo::CellInterpolationBase*> elements;
+    NuTo::DofContainer<NuTo::ElementInterface*> elements;
     elements[dof] = &element.get();
 
     NuTo::CellData cell(elements);


### PR DESCRIPTION
Just a renaming issue. `CellInterpolation...` contains an interpolation and dof values. For me, and some ppl I talked to, this should be called `Element`.

Plus, some minor changes regarding some documentation and renaming (remove r... in arguments). No big deal IMO. 