### PR TITLE
Update cmake version to 3.5 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
     - export PATH=/home/travis/miniconda/bin:$PATH
     - ./scripts/install_numpy.sh
     - ./scripts/install_gmsh.sh
+    - ./scripts/install_cmake.sh
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get -qq update
     - sudo apt-get install -y g++-6 clang libeigen3-dev libgcc-6-dev libiomp-dev swig3.0 doxygen python3-dev python3-numpy libboost-system1.55-dev libboost-filesystem1.55-dev libboost-test1.55-dev libboost-mpi1.55-dev libopenblas-dev libmetis-dev libmumps-seq-dev libann-dev libarpack2-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(NuTo)
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 option(BUILD_SHARED_LIBS "build NuTo libraries as shared libraries" TRUE)
 option(ENABLE_ARPACK

--- a/python/nuto/CMakeLists.txt
+++ b/python/nuto/CMakeLists.txt
@@ -20,6 +20,13 @@ message(STATUS "PYTHON_LIBRARIES = ${PYTHON_LIBRARIES}")
 message(STATUS "PYTHON_INCLUDE_DIRS = ${PYTHON_INCLUDE_DIRS}")
 message(STATUS "PYTHON_VERSION = ${PYTHON_VERSION}")
 
+# set numpy include path for generated wrapper files
+execute_process(COMMAND
+    ${CMAKE_SOURCE_DIR}/scripts/get_numpy_path.py
+    OUTPUT_VARIABLE NUMPY_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(PYTHON_CXX_FLAGS "${PYTHON_CXX_FLAGS} -I${NUMPY_PATH}")
+
 # SWIG required for interface files c++ and python
 message(STATUS "Checking for SWIG...")
 find_program(SWIG_EXECUTABLE NAMES swig3.0 swig swig2.0)

--- a/scripts/FindMUMPS.cmake
+++ b/scripts/FindMUMPS.cmake
@@ -36,7 +36,7 @@ endif()
 
 # search for header dmumps_c.h
 find_path(MUMPS_INCLUDE_DIR NAMES dmumps_c.h
-          HINTS ${_mumps_INCLUDE_SEARCH_DIRS})
+          HINTS ${_mumps_INCLUDE_SEARCH_DIRS} /usr/include/mumps-seq-shared/)
 
 if(UNIX AND MUMPS_FIND_STATIC_LIBRARY)
     set(MUMPS_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
@@ -47,8 +47,8 @@ if(UNIX AND MUMPS_FIND_STATIC_LIBRARY)
         NAMES mumps_common
         HINTS ${_mumps_LIBRARIES_SEARCH_DIRS})
 else()
-    find_library(_mumps_LIB_DMUMPS NAMES dmumps_seq)
-    find_library(_mumps_LIB_MUMPS_COMMON NAMES mumps_common_seq)
+    find_library(_mumps_LIB_DMUMPS NAMES dmumps_seq dmumps)
+    find_library(_mumps_LIB_MUMPS_COMMON NAMES mumps_common_seq mumps_common)
 endif()
 
 if(_mumps_LIB_DMUMPS AND _mumps_LIB_MUMPS_COMMON)

--- a/scripts/FindOPENBLAS.cmake
+++ b/scripts/FindOPENBLAS.cmake
@@ -35,7 +35,7 @@ endif()
 
 # check for BLAS libraries
 find_library(_Openblas_LIB_OpenBLAS
-    NAMES openblas
+    NAMES openblas blas
     HINTS ${_Openblas_LIBRARIES_SEARCH_DIRS})
 
 if(_Openblas_LIB_OpenBLAS)

--- a/scripts/NuToMacros.cmake
+++ b/scripts/NuToMacros.cmake
@@ -18,7 +18,7 @@ function(nuto_swig_module module_name interface_file)
         PROPERTIES LINK_FLAGS -Wl,-z,defs)
     # Additional build flags for module
     set_source_files_properties("${swig_generated_file_fullname}"
-        PROPERTIES COMPILE_FLAGS "${PYTHON_C_FLAGS}")
+        PROPERTIES COMPILE_FLAGS "${PYTHON_CXX_FLAGS}")
 endfunction()
 
 # `add_unit_test(SomeClass FilesItNeedsToLink)` builds the unit test of the

--- a/scripts/get_numpy_path.py
+++ b/scripts/get_numpy_path.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+import numpy.distutils as nd
+print(nd.misc_util.get_numpy_include_dirs()[0])

--- a/scripts/install_cmake.sh
+++ b/scripts/install_cmake.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ev
+# 3.5 is in Debian Stable and in 16.04, and has IMPORTED targets for boost
+wget https://cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.sh
+sudo sh cmake-3.5.2-Linux-x86_64.sh -- --skip-license --prefix=/usr


### PR DESCRIPTION
**Don't merge this!**

I wanted to update CMake to 3.5 on Travis to start working on #98. However, this doesn't work as you can see. I have no idea what causes this, and I don't know how to fix it (setting `include_directories` is not applied to the swig target module for some reason). If you want to have a crack at this

~~~python
import numpy.distutils as nd
print(nd.misc_util.get_numpy_include_dirs()[0])
~~~

will get you the correct include directory, also on Travis. You just need to tell CMake to use it. Most likely to be done with [target_include_directories](https://cmake.org/cmake/help/v3.0/command/target_include_directories.html). Good luck.