### PR TITLE
Remove template <TDim>. Only unit tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
     - if [[ "$CXX" == "clang++" ]]; then CXX=clang++ cmake $BUILD_OPTIONS $OPTIONS ..; fi
 script:
     - make -j2 unit
-    - make -j2 && ctest --output-on-failure
+    #- make -j2 && ctest --output-on-failure
 after_success:
     - cd ..
     - ./scripts/upload_coverage.sh

--- a/src/mechanics/cell/Cell.h
+++ b/src/mechanics/cell/Cell.h
@@ -9,12 +9,11 @@
 
 namespace NuTo
 {
-template <int TDim>
 class Cell : public CellInterface
 {
 public:
     Cell(const CellInterpolationBase& coordinateInterpolation, DofContainer<CellInterpolationBase*> cellinterpolation,
-         const IntegrationTypeBase& integrationType, const Integrand<TDim>& integrand)
+         const IntegrationTypeBase& integrationType, const Integrand& integrand)
         : mCoordinateInterpolation(coordinateInterpolation)
         , mCellInterpolation(cellinterpolation)
         , mIntegrationType(integrationType)
@@ -33,9 +32,9 @@ public:
         {
             auto ipCoords = mIntegrationType.GetLocalIntegrationPointCoordinates(iIP);
             auto ipWeight = mIntegrationType.GetIntegrationPointWeight(iIP);
-            Jacobian<TDim> jacobian(mCoordinateInterpolation.ExtractNodeValues(),
+            Jacobian jacobian(mCoordinateInterpolation.ExtractNodeValues(),
                                     mCoordinateInterpolation.GetDerivativeShapeFunctions(ipCoords));
-            CellIpData<TDim> cellipData(mCellInterpolation, jacobian, ipCoords);
+            CellIpData cellipData(mCellInterpolation, jacobian, ipCoords);
             gradient += mIntegrand[iIP].Gradient(cellData, cellipData) * jacobian.Det() * ipWeight;
         }
         return gradient;
@@ -50,9 +49,9 @@ public:
         {
             auto ipCoords = mIntegrationType.GetLocalIntegrationPointCoordinates(iIP);
             auto ipWeight = mIntegrationType.GetIntegrationPointWeight(iIP);
-            Jacobian<TDim> jacobian(mCoordinateInterpolation.ExtractNodeValues(),
+            Jacobian jacobian(mCoordinateInterpolation.ExtractNodeValues(),
                                     mCoordinateInterpolation.GetDerivativeShapeFunctions(ipCoords));
-            CellIpData<TDim> cellipData(mCellInterpolation, jacobian, ipCoords);
+            CellIpData cellipData(mCellInterpolation, jacobian, ipCoords);
             hessian0 += mIntegrand[iIP].Hessian0(cellData, cellipData) * jacobian.Det() * ipWeight;
         }
         return hessian0;
@@ -73,9 +72,9 @@ public:
         for (int iIP = 0; iIP < mIntegrationType.GetNumIntegrationPoints(); ++iIP)
         {
             auto ipCoords = mIntegrationType.GetLocalIntegrationPointCoordinates(iIP);
-            Jacobian<TDim> jacobian(mCoordinateInterpolation.ExtractNodeValues(),
+            Jacobian jacobian(mCoordinateInterpolation.ExtractNodeValues(),
                                     mCoordinateInterpolation.GetDerivativeShapeFunctions(ipCoords));
-            CellIpData<TDim> cellipData(mCellInterpolation, jacobian, ipCoords);
+            CellIpData cellipData(mCellInterpolation, jacobian, ipCoords);
             ipValues.push_back(mIntegrand[iIP].IPValues(cellData, cellipData));
         }
         return ipValues;
@@ -85,6 +84,6 @@ private:
     const CellInterpolationBase& mCoordinateInterpolation;
     DofContainer<CellInterpolationBase*> mCellInterpolation;
     const IntegrationTypeBase& mIntegrationType;
-    boost::ptr_vector<Integrand<TDim>> mIntegrand;
+    boost::ptr_vector<Integrand> mIntegrand;
 };
 } /* NuTo */

--- a/src/mechanics/cell/CellIpData.h
+++ b/src/mechanics/cell/CellIpData.h
@@ -9,11 +9,10 @@ namespace NuTo
 
 
 //! @brief Similar to NuTo::CellData, but for N and B
-template <int TDim>
 class CellIpData
 {
 public:
-    CellIpData(const DofContainer<CellInterpolationBase*> cellInterpolation, const NuTo::Jacobian<TDim>& jacobian,
+    CellIpData(const DofContainer<CellInterpolationBase*> cellInterpolation, const NuTo::Jacobian& jacobian,
                const NaturalCoords& ipCoords)
         : mCellInterpolation(cellInterpolation)
         , mJacobian(jacobian)
@@ -110,7 +109,7 @@ private:
     }
 
     const DofContainer<CellInterpolationBase*> mCellInterpolation;
-    const NuTo::Jacobian<TDim>& mJacobian;
+    const NuTo::Jacobian& mJacobian;
     const NaturalCoords& mIPCoords;
 };
 } /* NuTo */

--- a/src/mechanics/cell/Integrand.h
+++ b/src/mechanics/cell/Integrand.h
@@ -7,15 +7,14 @@
 
 namespace NuTo
 {
-template <int TDim>
 class Integrand
 {
 public:
-    virtual Integrand<TDim>* Clone() const = 0;
+    virtual Integrand* Clone() const = 0;
     virtual ~Integrand() = default;
-    virtual DofVector<double> Gradient(const CellData&, const CellIpData<TDim>&) = 0;
-    virtual DofMatrix<double> Hessian0(const CellData&, const CellIpData<TDim>&) = 0;
-    virtual std::vector<IPValue> IPValues(const CellData&, const CellIpData<TDim>&) = 0;
+    virtual DofVector<double> Gradient(const CellData&, const CellIpData&) = 0;
+    virtual DofMatrix<double> Hessian0(const CellData&, const CellIpData&) = 0;
+    virtual std::vector<IPValue> IPValues(const CellData&, const CellIpData&) = 0;
 };
 
 } /* NuTo */

--- a/src/mechanics/cell/IntegrandLinearElastic.h
+++ b/src/mechanics/cell/IntegrandLinearElastic.h
@@ -8,7 +8,7 @@ namespace NuTo
 
 
 template <int TDim>
-class IntegrandLinearElastic : public NuTo::Integrand<TDim>
+class IntegrandLinearElastic : public NuTo::Integrand
 {
 public:
     IntegrandLinearElastic(const NuTo::DofType& dofType, const Laws::LinearElastic<TDim>& law)
@@ -17,13 +17,13 @@ public:
     {
     }
 
-    virtual NuTo::Integrand<TDim>* Clone() const override
+    virtual NuTo::Integrand* Clone() const override
     {
         return new IntegrandLinearElastic<TDim>(mDofType, mLaw);
     }
 
     NuTo::DofVector<double> Gradient(const NuTo::CellData& cellData,
-                                     const NuTo::CellIpData<TDim>& cellIpData) override
+                                     const NuTo::CellIpData& cellIpData) override
     {
         NuTo::BMatrixStrain B = cellIpData.GetBMatrixStrain(mDofType);
         NuTo::NodeValues u = cellData.GetNodeValues(mDofType);
@@ -35,7 +35,7 @@ public:
     }
 
     NuTo::DofMatrix<double> Hessian0(const NuTo::CellData& cellData,
-                                     const NuTo::CellIpData<TDim>& cellIpData) override
+                                     const NuTo::CellIpData& cellIpData) override
     {
         NuTo::BMatrixStrain B = cellIpData.GetBMatrixStrain(mDofType);
         NuTo::DofMatrix<double> hessian0;
@@ -45,7 +45,7 @@ public:
         return hessian0;
     }
     std::vector<NuTo::IPValue> IPValues(const NuTo::CellData& cellData,
-                                        const NuTo::CellIpData<TDim>& cellIpData) override
+                                        const NuTo::CellIpData& cellIpData) override
     {
         NuTo::BMatrixStrain B = cellIpData.GetBMatrixStrain(mDofType);
         NuTo::NodeValues u = cellData.GetNodeValues(mDofType);

--- a/test/mechanics/cell/Cell.cpp
+++ b/test/mechanics/cell/Cell.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(CellLetsSee)
     NuTo::Laws::LinearElastic<2> law(E, 0.0, NuTo::ePlaneState::PLANE_STRAIN);
     NuTo::IntegrandLinearElastic<2> integrand({dofDispl}, law);
 
-    NuTo::Cell<2> cell(coordinateElement, elements, intType.get(), integrand);
+    NuTo::Cell cell(coordinateElement, elements, intType.get(), integrand);
 
     BoostUnitTest::CheckVector(cell.Gradient()[dofDispl], Eigen::VectorXd::Zero(8), 8);
 

--- a/test/mechanics/cell/CellIpData.cpp
+++ b/test/mechanics/cell/CellIpData.cpp
@@ -67,8 +67,8 @@ BOOST_AUTO_TEST_CASE(CellIPData2D)
     NuTo::DerivativeShapeFunctionsNatural derivativeForJacobian =
             NuTo::ShapeFunctions2D::DerivativeShapeFunctionsTriangleOrder1(ipCoords);
 
-    NuTo::Jacobian<2> jac(nodalValues, derivativeForJacobian);
-    NuTo::CellIpData<2> ipData(elements, jac, ipCoords);
+    NuTo::Jacobian jac(nodalValues, derivativeForJacobian);
+    NuTo::CellIpData ipData(elements, jac, ipCoords);
 
     BoostUnitTest::CheckEigenMatrix(jac.Inv(), Eigen::Matrix2d::Identity());
 
@@ -117,8 +117,8 @@ BOOST_AUTO_TEST_CASE(InterpolationBStrain3D)
     NuTo::DerivativeShapeFunctionsNatural derivativeForJacobian =
             NuTo::ShapeFunctions3D::DerivativeShapeFunctionsTetrahedronOrder1();
 
-    NuTo::Jacobian<3> jac(nodalValues, derivativeForJacobian);
-    NuTo::CellIpData<3> ipData(elements, jac, ipCoords);
+    NuTo::Jacobian jac(nodalValues, derivativeForJacobian);
+    NuTo::CellIpData ipData(elements, jac, ipCoords);
 
     BoostUnitTest::CheckEigenMatrix(jac.Inv(), Eigen::Matrix3d::Identity());
     Eigen::MatrixXd expected = Eigen::MatrixXd::Zero(6, 9);

--- a/test/mechanics/cell/Jacobian.cpp
+++ b/test/mechanics/cell/Jacobian.cpp
@@ -6,7 +6,7 @@ BOOST_AUTO_TEST_CASE(Jacobian1DDet)
 {
     Eigen::MatrixXd B = NuTo::ShapeFunctions1D::DerivativeShapeFunctionsTrussOrder1();
     Eigen::VectorXd coordinates = Eigen::Vector2d({12., 17});
-    NuTo::Jacobian<1> jacobian(coordinates, B);
+    NuTo::Jacobian jacobian(coordinates, B);
     BOOST_CHECK_CLOSE(jacobian.Det(), 2.5, 1.e-10);
 }
 
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_CASE(Jacobian2DDet)
     coordinates << 0, 0, 2, 0, 2, 8, 0, 8; // rectangle from (0,0) to (2,8)
 
 
-    NuTo::Jacobian<2> jacobian(coordinates, B);
+    NuTo::Jacobian jacobian(coordinates, B);
     BOOST_CHECK_CLOSE(jacobian.Det(), 4, 1.e-10); // reference area = 4, this area = 16;
 }
 
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(Jacobian3DDet)
     Eigen::VectorXd coordinates = Eigen::VectorXd(12);
     coordinates << 0, 0, 0, 10, 0, 0, 0, 5, 0, 0, 0, 42;
 
-    NuTo::Jacobian<3> jacobian(coordinates, B);
+    NuTo::Jacobian jacobian(coordinates, B);
     BOOST_CHECK_CLOSE(jacobian.Det(), 10 * 5 * 42, 1.e-10);
 }
 


### PR DESCRIPTION
This allows also removing it everywhere else (Cell, Integrand, CellIpData)

The jacobian calculation is actually performed on fixed size matrices to keep it efficient. Eigen apparently swaps the algorithm for `.inverse()` and `.determinant()` for small, fixed size matrices. Only the results are saved in a dynamic matrix (max size 3x3). On top, I avoid the strange `nodeBlockValues` loop by using the (far more efficient) `Eigen::Map`. 

To reduce the load on travis, only unit tests are executed.