### PR TITLE
Remove running examples/integr tests from targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ before_script:
     - if [[ "$CXX" == "clang++" ]]; then CXX=clang++ cmake $BUILD_OPTIONS ..; fi
 script:
     - make -j2 unit
-    - make -j2 && make -j2 integrationtests # need to make python modules before integrationtests
-    - if [[ "$EXAMPLES" == "TRUE" ]]; then make -j2 examples; fi
+    - make -j2 && make -j2 integrationtests && ctest -R integration --output-on-failure # need to make python modules before integrationtests
+    - if [[ "$EXAMPLES" == "TRUE" ]]; then make -j2 examples && ctest -R examples --output-on-failure; fi
     - sudo make install
     - cd ..
     - ./scripts/check_install.sh

--- a/applications/benchmark/CMakeLists.txt
+++ b/applications/benchmark/CMakeLists.txt
@@ -4,6 +4,7 @@ foreach(test
     BuildGradient
     LinearElasticity
     LinearElasticityExplicit
+    LinearElasticityOPENMP
     LinearElasticityVisualize
     AssembleSparseMatrix
     ShapeFunctionMemoization
@@ -12,19 +13,12 @@ foreach(test
 
     add_executable(${test} EXCLUDE_FROM_ALL ${test}.cpp)
     target_link_libraries(${test} Mechanics Math Base Visualize)
-    add_test(benchmark::${test} ${CMAKE_CURRENT_BINARY_DIR}/${test})
     append_to_benchmarks(${test})
 endforeach()
 
 if(PARDISO_FOUND)
     target_link_libraries(Solvers ${PARDISO_LIBRARIES} ${BLAS_LIBRARIES})
 endif()
-
-
-add_executable(LinearElasticityOPENMP
-    EXCLUDE_FROM_ALL LinearElasticityOPENMP.cpp)
-target_link_libraries(LinearElasticityOPENMP Mechanics Math Base Visualize)
-append_to_benchmarks(LinearElasticityOPENMP)
 
 add_executable(DenseSpherePacking EXCLUDE_FROM_ALL DenseSpherePacking.cpp)
 target_link_libraries(DenseSpherePacking Math Base GeometryConcrete)

--- a/applications/examples/CMakeLists.txt
+++ b/applications/examples/CMakeLists.txt
@@ -3,8 +3,4 @@ unset(all_examples CACHE)
 add_subdirectory(c++)
 add_subdirectory(python)
 
-add_custom_target(examples
-    COMMAND ctest -R example --output-on-failure
-    DEPENDS ${all_examples}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    )
+add_custom_target(examples DEPENDS ${all_examples})

--- a/applications/integrationtests/CMakeLists.txt
+++ b/applications/integrationtests/CMakeLists.txt
@@ -7,8 +7,4 @@ add_subdirectory(metamodel)
 add_subdirectory(optimize)
 add_subdirectory(visualize)
 
-add_custom_target(integrationtests
-    COMMAND ctest -R integration --output-on-failure
-    DEPENDS ${all_integration_tests}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    )
+add_custom_target(integrationtests DEPENDS ${all_integration_tests})


### PR DESCRIPTION
Previously, `make examples` and `make integrationtests` not only build
the respective executables, but also ran them. This commit changes that,
so that they are only build. If you want to run the tests, use `ctest -R
examples` and `ctest -R integration`, respectively.