### PR TITLE
Pde mesh move problem

### DIFF
--- a/src/base/ValueVector.h
+++ b/src/base/ValueVector.h
@@ -1,27 +1,75 @@
 #pragma once
 
-#include <boost/ptr_container/ptr_vector.hpp>
+#include <vector>
+#include <memory>
+#include <boost/iterator/indirect_iterator.hpp>
+
 
 namespace NuTo
 {
 
 //! @brief container that stores values of T and keeps references to these values valid
+//! @remark Normally, it is a no-brainer to use boost::ptr_vector here. It provides all
+//! the nice value semantics for free. However, there is an issue regarding move.
+//!         https://stackoverflow.com/questions/44130076/moving-a-boostptr-vector
+//! Therefore, here is a custom implementation with only the basic features.
 template <typename T>
-class ValueVector : public boost::ptr_vector<T>
+class ValueVector
 {
-public:
+    using Data = std::vector<std::unique_ptr<T>>;
+    //! @brief indirect (dereferencing) iterator to provide value semantics for the iterators
+    typedef boost::indirect_iterator<typename Data::iterator> IndirectIterator;
+    typedef boost::indirect_iterator<typename Data::const_iterator> ConstIndirectIterator;
 
+public:
     template <typename... TArgs>
     T& Add(TArgs&&... args)
     {
-        this->push_back(new T(std::forward<TArgs>(args)...));
-        return this->back();
+        mData.push_back(std::make_unique<T>(std::forward<TArgs>(args)...));
+        return *mData.back();
     }
 
     T& Add(T&& t)
     {
-        this->push_back(new T(t));
-        return this->back();
+        mData.push_back(std::make_unique<T>(std::move(t)));
+        return *mData.back();
     }
+
+    IndirectIterator begin()
+    {
+        return mData.begin();
+    }
+
+    IndirectIterator end()
+    {
+        return mData.end();
+    }
+
+    ConstIndirectIterator begin() const
+    {
+        return mData.begin();
+    }
+
+    ConstIndirectIterator end() const
+    {
+        return mData.end();
+    }
+
+    typename Data::size_type Size() const
+    {
+        return mData.size();
+    }
+
+    const T& operator[](int i) const
+    {
+        return *(mData[i]);
+    }
+    T& operator[](int i)
+    {
+        return *(mData[i]);
+    }
+
+private:
+    Data mData;
 };
 } /* NuTo */

--- a/src/base/ValueVector.h
+++ b/src/base/ValueVector.h
@@ -62,11 +62,21 @@ public:
 
     const T& operator[](int i) const
     {
-        return *(mData[i]);
+        return *mData[i];
     }
     T& operator[](int i)
     {
-        return *(mData[i]);
+        return *mData[i];
+    }
+
+    IndirectIterator Erase(IndirectIterator it)
+    {
+        return mData.erase(it.base());
+    }
+
+    IndirectIterator Erase(IndirectIterator from, IndirectIterator to)
+    {
+        return mData.erase(from.base(), to.base());
     }
 
 private:

--- a/src/mechanics/elements/ElementFem.h
+++ b/src/mechanics/elements/ElementFem.h
@@ -13,21 +13,21 @@ class ElementFem : public ElementInterface
 {
 public:
     ElementFem(std::vector<NodeSimple*> nodes, const InterpolationSimple& interpolation)
-        : mNodes(nodes)
-        , mInterpolation(interpolation)
+        : mInterpolation(interpolation)
     {
+        for (NodeSimple* node : nodes)
+            mNodes.push_back(*node);
         assert(mNodes.size() == interpolation.GetNumNodes());
-        assert(mNodes.front()->GetNumValues() == interpolation.GetDofDimension());
+        assert(mNodes.front().get().GetNumValues() == interpolation.GetDofDimension());
     }
 
     ElementFem(std::initializer_list<std::reference_wrapper<NuTo::NodeSimple>> nodes,
                const InterpolationSimple& interpolation)
-        : mInterpolation(interpolation)
+        : mNodes(nodes)
+        , mInterpolation(interpolation)
     {
-        for (NuTo::NodeSimple& node : nodes)
-            mNodes.push_back(&node);
         assert(mNodes.size() == interpolation.GetNumNodes());
-        assert(mNodes.front()->GetNumValues() == interpolation.GetDofDimension());
+        assert(mNodes.front().get().GetNumValues() == interpolation.GetDofDimension());
     }
 
     virtual NodeValues ExtractNodeValues() const override
@@ -35,7 +35,7 @@ public:
         const int dim = GetDofDimension();
         Eigen::VectorXd nodeValues(GetNumNodes() * dim);
         for (size_t i = 0; i < GetNumNodes(); ++i)
-            nodeValues.segment(dim * i, dim) = mNodes[i]->GetValues();
+            nodeValues.segment(dim * i, dim) = GetNode(i).GetValues();
         return nodeValues;
     }
 
@@ -88,18 +88,18 @@ public:
     NodeSimple& GetNode(int i)
     {
         assert(i < mNodes.size());
-        return *mNodes[i];
+        return mNodes[i];
     }
 
 
     const NodeSimple& GetNode(int i) const
     {
         assert(i < mNodes.size());
-        return *mNodes[i];
+        return mNodes[i];
     }
 
 private:
-    std::vector<NuTo::NodeSimple*> mNodes;
+    std::vector<std::reference_wrapper<NodeSimple>> mNodes;
     std::reference_wrapper<const InterpolationSimple> mInterpolation;
 };
 } /* NuTo */

--- a/src/mechanics/mesh/MeshFem.h
+++ b/src/mechanics/mesh/MeshFem.h
@@ -8,6 +8,9 @@
 
 namespace NuTo
 {
+//! @brief contains the nodes, elements and interpolations for a classic finite element mesh
+//! @remark Elements contain references to nodes. Thus, a copy of MeshFem is not trivially possible and only move is
+//! allowed
 class MeshFem
 {
 public:
@@ -19,8 +22,10 @@ public:
     MeshFem(MeshFem&&) = default;
     MeshFem& operator=(MeshFem&&) = default;
 
+    //! @brief adds a clone of `interpolation` to the mesh (prototype pattern)
+    //! @param interpolation interpolation that is cloned and added
+    //! @return reference to the cloned object
     InterpolationSimple& CreateInterpolation(const InterpolationSimple& interpolation);
-
 
     //! @brief selects a coordinate at given `coords`
     //! @param coords global coordinates

--- a/src/mechanics/mesh/MeshFem.h
+++ b/src/mechanics/mesh/MeshFem.h
@@ -11,6 +11,14 @@ namespace NuTo
 class MeshFem
 {
 public:
+    MeshFem() = default;
+
+    MeshFem(const MeshFem&) = delete;
+    MeshFem& operator=(const MeshFem&) = delete;
+
+    MeshFem(MeshFem&&) = default;
+    MeshFem& operator=(MeshFem&&) = default;
+
     InterpolationSimple& CreateInterpolation(const InterpolationSimple& interpolation);
 
 
@@ -41,9 +49,8 @@ public:
     //! @param axisOffset distance of the node to the axis
     //! @param tol selection tolerance
     //! @return group with selected nodes, the group may be empty if no nodes were found
-    Groups::Group<NodeSimple> NodesAtAxis(eDirection direction, double axisOffset = 0.,
-                                          double tol = 1.e-10); 
-    
+    Groups::Group<NodeSimple> NodesAtAxis(eDirection direction, double axisOffset = 0., double tol = 1.e-10);
+
     //! @brief selects all nodes of `dofType`
     //! @return group containing all selected nodes
     Groups::Group<NodeSimple> NodesTotal(DofType dofType);

--- a/src/mechanics/mesh/MeshFemDofConvert.cpp
+++ b/src/mechanics/mesh/MeshFemDofConvert.cpp
@@ -70,7 +70,7 @@ public:
                             return &entry;
                 }
         return nullptr; // TODO17:  This is a classic case for the c++17 feature std::optional<T>. Here we have to
-                        // introduce pointers to our precious interface.
+        // introduce pointers to our precious interface.
     }
 
 private:
@@ -112,7 +112,7 @@ struct NodePoint : Eigen::Vector3d // to inherit operator[]
 
 SubBoxes<NodePoint>::Domain SetupSubBoxDomain(const NuTo::MeshFem& mesh, int numBoxesPerDirection, double eps)
 {
-    Eigen::VectorXd start = mesh.Elements.front().CoordinateElement().GetNode(0).GetValues();
+    Eigen::VectorXd start = mesh.Elements[0].CoordinateElement().GetNode(0).GetValues();
     Eigen::VectorXd end = start;
 
     unsigned long numNodesTotal = 0;

--- a/src/mechanics/mesh/UnitMeshFem.cpp
+++ b/src/mechanics/mesh/UnitMeshFem.cpp
@@ -54,11 +54,10 @@ MeshFem UnitMeshFem::CreateQuads(int numX, int numY)
 
 MeshFem UnitMeshFem::Transform(MeshFem&& oldMesh, std::function<Eigen::VectorXd(Eigen::VectorXd)> f)
 {
-    MeshFem newMesh = std::move(oldMesh);
-    // Build a group to avoid duplicates. Otherwise, the transformation is applied multiple times.
-    // This is, however, a bit of a bottleneck for big meshes.
-    for (auto& node : newMesh.NodesTotal())
+    // Build a group (MeshFem::NodesTotal() selects all coordinate nodes) to avoid duplicates. Otherwise, the
+    // transformation is applied multiple times. This is, however, a bit of a bottleneck for big meshes.
+    for (auto& node : oldMesh.NodesTotal())
         node.SetValues(f(node.GetValues()));
 
-    return newMesh;
+    return std::move(oldMesh);
 }

--- a/src/mechanics/mesh/UnitMeshFem.cpp
+++ b/src/mechanics/mesh/UnitMeshFem.cpp
@@ -54,10 +54,11 @@ MeshFem UnitMeshFem::CreateQuads(int numX, int numY)
 
 MeshFem UnitMeshFem::Transform(MeshFem&& oldMesh, std::function<Eigen::VectorXd(Eigen::VectorXd)> f)
 {
+    MeshFem newMesh = std::move(oldMesh);
     // Build a group to avoid duplicates. Otherwise, the transformation is applied multiple times.
-    // This is, however, a bit of a bottleneck for big meshes. 
-    for (auto& node : oldMesh.NodesTotal())
+    // This is, however, a bit of a bottleneck for big meshes.
+    for (auto& node : newMesh.NodesTotal())
         node.SetValues(f(node.GetValues()));
 
-    return oldMesh;
+    return newMesh;
 }

--- a/src/mechanics/mesh/UnitMeshFem.h
+++ b/src/mechanics/mesh/UnitMeshFem.h
@@ -19,7 +19,7 @@ MeshFem CreateTriangles(int numX, int numY);
 MeshFem CreateQuads(int numX, int numY);
 
 //! @brief transforms a mesh with a given transformation function f
-//! @param oldMesh mesh that is transformed. Call with an xvalue of mesh.  
+//! @param oldMesh mesh that is transformed. Call with an xvalue of mesh.
 //! @param f transformation function
 MeshFem Transform(MeshFem&& oldMesh, std::function<Eigen::VectorXd(Eigen::VectorXd)> f);
 

--- a/test/base/ValueVector.cpp
+++ b/test/base/ValueVector.cpp
@@ -42,6 +42,7 @@ BOOST_AUTO_TEST_CASE(ValueVectorForwarding)
 
     NuTo::ValueVector<Foo> v;
     v.Add(4, Bar(42));
+    v.Add(4, 42);
 
     BOOST_CHECK_EQUAL(v[0].m, 4);
 }

--- a/test/base/ValueVector.cpp
+++ b/test/base/ValueVector.cpp
@@ -9,19 +9,16 @@ BOOST_AUTO_TEST_CASE(ValueVectorValidReferences)
     for (int i = 0; i < 1e6; ++i)
         v.Add(i);
 
-    int& lastElement = v.Add(4);
-    v.erase_if([](int a) { return a >= 100; });
-    BOOST_CHECK_EQUAL(v.size(), 102); // 100 remaining elements + first(42) + last(4)
-
     BOOST_CHECK_EQUAL(firstElement, 42);
-    BOOST_CHECK_EQUAL(lastElement, 4);
 }
 
 BOOST_AUTO_TEST_CASE(ValueVectorForwarding)
 {
     struct Bar
     {
-        Bar(int) {}
+        Bar(int)
+        {
+        }
     };
 
     struct Foo
@@ -36,7 +33,7 @@ BOOST_AUTO_TEST_CASE(ValueVectorForwarding)
     NuTo::ValueVector<Foo> v;
     v.Add(4, Bar(42));
 
-    BOOST_CHECK_EQUAL(v.front().m, 4); 
+    BOOST_CHECK_EQUAL(v[0].m, 4);
 }
 
 BOOST_AUTO_TEST_CASE(ValueVectorRangeLoop)

--- a/test/base/ValueVector.cpp
+++ b/test/base/ValueVector.cpp
@@ -9,7 +9,17 @@ BOOST_AUTO_TEST_CASE(ValueVectorValidReferences)
     for (int i = 0; i < 1e6; ++i)
         v.Add(i);
 
+    int& lastElement = v.Add(4);
+
+    v.Erase(v.begin() + 100, v.end() - 2);
+
+    BOOST_CHECK_EQUAL(v.Size(), 102);
+
     BOOST_CHECK_EQUAL(firstElement, 42);
+    BOOST_CHECK_EQUAL(lastElement, 4);
+
+    v.Erase(std::find(v.begin(), v.end(), firstElement));
+    BOOST_CHECK_EQUAL(v.Size(), 101);
 }
 
 BOOST_AUTO_TEST_CASE(ValueVectorForwarding)

--- a/test/mechanics/mesh/MeshFem.cpp
+++ b/test/mechanics/mesh/MeshFem.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(MeshAddStuff)
     NuTo::DofType d("Dof", 1);
     NuTo::MeshFem mesh = DummyMesh(d);
 
-    auto& e0 = mesh.Elements.front();
+    auto& e0 = mesh.Elements[0];
     BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({1, 0, 2, 0, 0, 3}), 6);
 
     mesh.Nodes[0].SetValue(0, 4);
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(MeshAddStuff)
 
     NuTo::MeshFem meshMoved = std::move(mesh);
     meshMoved.Nodes[0].SetValue(0, 42);
-    auto& e0FromMove = meshMoved.Elements.front();
+    auto& e0FromMove = meshMoved.Elements[0];
     BoostUnitTest::CheckVector(e0FromMove.CoordinateElement().ExtractNodeValues(),
                                std::vector<double>({42, 0, 2, 0, 0, 3}), 6);
 }
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
     mesh.Elements.Add({{{n1, n3, n2}, interpolationCoords}});
 
     int expectedNumCoordinateNodes = 4;
-    BOOST_CHECK_EQUAL(mesh.Nodes.size(), expectedNumCoordinateNodes);
+    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumCoordinateNodes);
 
 
     // add linear dof type
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
 
     int expectedNumDof0Nodes = expectedNumCoordinateNodes; // same interpolation
 
-    BOOST_CHECK_EQUAL(mesh.Nodes.size(), expectedNumCoordinateNodes + expectedNumDof0Nodes);
+    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumCoordinateNodes + expectedNumDof0Nodes);
     BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 0), dof0));
 
 
@@ -154,5 +154,5 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
     NuTo::AddDofInterpolation(&mesh, dof1, interpolationQuadratic);
 
     int expectedNumDof1Nodes = 9;
-    BOOST_CHECK_EQUAL(mesh.Nodes.size(), expectedNumCoordinateNodes + expectedNumDof0Nodes + expectedNumDof1Nodes);
+    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumCoordinateNodes + expectedNumDof0Nodes + expectedNumDof1Nodes);
 }

--- a/test/mechanics/mesh/MeshFem.cpp
+++ b/test/mechanics/mesh/MeshFem.cpp
@@ -4,6 +4,11 @@
 #include "mechanics/interpolation/InterpolationTriangleLinear.h"
 #include "mechanics/interpolation/InterpolationTriangleQuadratic.h"
 
+void SetStuff(NuTo::MeshFem& m)
+{
+    m.Nodes[0].SetValue(0, 0);
+}
+
 NuTo::MeshFem DummyMesh(NuTo::DofType dofType)
 {
     NuTo::MeshFem mesh;
@@ -30,6 +35,15 @@ BOOST_AUTO_TEST_CASE(MeshAddStuff)
 
     auto& e0 = mesh.Elements.front();
     BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({1, 0, 2, 0, 0, 3}), 6);
+
+    mesh.Nodes[0].SetValue(0, 4);
+    BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({4, 0, 2, 0, 0, 3}), 6);
+
+    NuTo::MeshFem meshMoved = std::move(mesh);
+    meshMoved.Nodes[0].SetValue(0, 42);
+    auto& e0FromMove = meshMoved.Elements.front();
+    BoostUnitTest::CheckVector(e0FromMove.CoordinateElement().ExtractNodeValues(),
+                               std::vector<double>({42, 0, 2, 0, 0, 3}), 6);
 }
 
 BOOST_AUTO_TEST_CASE(MeshNodeSelectionCoords)

--- a/test/mechanics/mesh/UnitMeshFem.cpp
+++ b/test/mechanics/mesh/UnitMeshFem.cpp
@@ -1,7 +1,7 @@
 #include "BoostUnitTest.h"
 #include "mechanics/mesh/UnitMeshFem.h"
 
-void Check2DMesh(NuTo::MeshFem mesh)
+void Check2DMesh(NuTo::MeshFem& mesh)
 {
     BOOST_CHECK_EQUAL(mesh.Nodes.size(), 3 * 8);
 
@@ -10,7 +10,6 @@ void Check2DMesh(NuTo::MeshFem mesh)
 
     BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(1. / 2., 1. / 7.)));
     BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(1. / 2., 5. / 7.)));
-
 
     auto f = [](Eigen::VectorXd coords) // transforms mesh to (42,4) -- (44, 11)
     {
@@ -22,11 +21,11 @@ void Check2DMesh(NuTo::MeshFem mesh)
 
     NuTo::MeshFem transformedMesh = NuTo::UnitMeshFem::Transform(std::move(mesh), f);
 
-    BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(42., 4.)));
-    BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(44., 11.)));
+    BOOST_CHECK_NO_THROW(transformedMesh.NodeAtCoordinate(Eigen::Vector2d(42., 4.)));
+    BOOST_CHECK_NO_THROW(transformedMesh.NodeAtCoordinate(Eigen::Vector2d(44., 11.)));
 
-    BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(43., 5.)));
-    BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(43., 9.)));
+    BOOST_CHECK_NO_THROW(transformedMesh.NodeAtCoordinate(Eigen::Vector2d(43., 5.)));
+    BOOST_CHECK_NO_THROW(transformedMesh.NodeAtCoordinate(Eigen::Vector2d(43., 9.)));
 }
 
 BOOST_AUTO_TEST_CASE(MeshQuad)
@@ -41,4 +40,27 @@ BOOST_AUTO_TEST_CASE(MeshTriangle)
     auto mesh = NuTo::UnitMeshFem::CreateTriangles(2, 7);
     BOOST_CHECK_EQUAL(mesh.Elements.size(), 2 * 7 * 2);
     Check2DMesh(mesh);
+}
+
+BOOST_AUTO_TEST_CASE(MeshValidAfterTransform)
+{
+    auto mesh = NuTo::UnitMeshFem::CreateQuads(1, 1);
+    Eigen::VectorXd expected(8);
+    expected << 0, 0, 1, 0, 1, 1, 0, 1;
+
+    auto& coordinateElement = mesh.Elements[0].CoordinateElement();
+    BoostUnitTest::CheckEigenMatrix(coordinateElement.ExtractNodeValues(), expected);
+
+    auto f = [](Eigen::VectorXd coords) { return Eigen::Vector2d(coords[0] * 4, coords[1] * 42); };
+
+    NuTo::MeshFem transformedMesh = NuTo::UnitMeshFem::Transform(std::move(mesh), f);
+    auto& transformedCoordinateElement = transformedMesh.Elements[0].CoordinateElement();
+    expected << 0, 0, 4, 0, 4, 42, 0, 42;
+    BoostUnitTest::CheckEigenMatrix(transformedCoordinateElement.ExtractNodeValues(), expected);
+
+    mesh.Nodes[0].SetValue(0, -121751);
+
+    transformedMesh.Nodes[0].SetValue(0, 6174);
+    expected << 6174, 0, 4, 0, 4, 42, 0, 42;
+    BoostUnitTest::CheckEigenMatrix(transformedCoordinateElement.ExtractNodeValues(), expected);
 }

--- a/test/mechanics/mesh/UnitMeshFem.cpp
+++ b/test/mechanics/mesh/UnitMeshFem.cpp
@@ -3,7 +3,7 @@
 
 void Check2DMesh(NuTo::MeshFem& mesh)
 {
-    BOOST_CHECK_EQUAL(mesh.Nodes.size(), 3 * 8);
+    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), 3 * 8);
 
     BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0., 0.)));
     BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(1., 1.)));
@@ -31,14 +31,14 @@ void Check2DMesh(NuTo::MeshFem& mesh)
 BOOST_AUTO_TEST_CASE(MeshQuad)
 {
     auto mesh = NuTo::UnitMeshFem::CreateQuads(2, 7);
-    BOOST_CHECK_EQUAL(mesh.Elements.size(), 2 * 7);
+    BOOST_CHECK_EQUAL(mesh.Elements.Size(), 2 * 7);
     Check2DMesh(mesh);
 }
 
 BOOST_AUTO_TEST_CASE(MeshTriangle)
 {
     auto mesh = NuTo::UnitMeshFem::CreateTriangles(2, 7);
-    BOOST_CHECK_EQUAL(mesh.Elements.size(), 2 * 7 * 2);
+    BOOST_CHECK_EQUAL(mesh.Elements.Size(), 2 * 7 * 2);
     Check2DMesh(mesh);
 }
 
@@ -57,8 +57,6 @@ BOOST_AUTO_TEST_CASE(MeshValidAfterTransform)
     auto& transformedCoordinateElement = transformedMesh.Elements[0].CoordinateElement();
     expected << 0, 0, 4, 0, 4, 42, 0, 42;
     BoostUnitTest::CheckEigenMatrix(transformedCoordinateElement.ExtractNodeValues(), expected);
-
-    mesh.Nodes[0].SetValue(0, -121751);
 
     transformedMesh.Nodes[0].SetValue(0, 6174);
     expected << 6174, 0, 4, 0, 4, 42, 0, 42;


### PR DESCRIPTION
`ValueVector.h:`
~~~
//! @brief container that stores values of T and keeps references to these values valid
//! @remark Normally, it is a no-brainer to use boost::ptr_vector here. It provides all
//! the nice value semantics for free. However, there is an issue regarding move.
//!         https://stackoverflow.com/questions/44130076/moving-a-boostptr-vector
//! Therefore, here is a custom implementation with only the basic features.
~~~

We want our mesh to be movable. `boost::ptr_vector` does not behave as expected and is replaced.