### PR TITLE
Pde remove dof dimension

### DIFF
--- a/applications/benchmark/BuildGradient.cpp
+++ b/applications/benchmark/BuildGradient.cpp
@@ -168,7 +168,7 @@ static void NuToPde(benchmark::State& state)
     NuTo::NodeSimple n6(Eigen::Vector2d({0.5, 1}));
     NuTo::NodeSimple n7(Eigen::Vector2d({0, 0.5}));
     std::vector<NuTo::NodeSimple*> coordNodes({&n0, &n1, &n2, &n3, &n4, &n5, &n6, &n7});
-    NuTo::InterpolationQuadSerendipity coordInterpolation(2);
+    NuTo::InterpolationQuadSerendipity coordInterpolation;
     NuTo::ElementFem coordElement(coordNodes, coordInterpolation);
 
     NuTo::NodeSimple nd0(Eigen::Vector2d({0, 0}));
@@ -180,7 +180,7 @@ static void NuToPde(benchmark::State& state)
     NuTo::NodeSimple nd6(Eigen::Vector2d({0, 0}));
     NuTo::NodeSimple nd7(Eigen::Vector2d({0, 0}));
     std::vector<NuTo::NodeSimple*> displNodes({&nd0, &nd1, &nd2, &nd3, &nd4, &nd5, &nd6, &nd7});
-    NuTo::InterpolationQuadSerendipity displInterpolation(2);
+    NuTo::InterpolationQuadSerendipity displInterpolation;
     NuTo::ElementFem displElement(displNodes, displInterpolation);
 
     NuTo::DofType displDof("Displacements", 2);

--- a/applications/benchmark/MeshFemBenchmark.cpp
+++ b/applications/benchmark/MeshFemBenchmark.cpp
@@ -26,7 +26,7 @@ static void Create(benchmark::State& state)
 static void Convert(benchmark::State& state)
 {
     const int n = state.range(0);
-    NuTo::InterpolationTriangleLinear interpolation(2);
+    NuTo::InterpolationTriangleLinear interpolation;
     for (auto _ : state)
     {
         NuTo::MeshFem mesh = NuTo::UnitMeshFem::CreateTriangles(n, n);

--- a/src/mechanics/elements/ElementFem.h
+++ b/src/mechanics/elements/ElementFem.h
@@ -18,7 +18,6 @@ public:
         for (NodeSimple* node : nodes)
             mNodes.push_back(*node);
         assert(static_cast<int>(mNodes.size()) == interpolation.GetNumNodes());
-        assert(mNodes.front().get().GetNumValues() == interpolation.GetDofDimension());
     }
 
     ElementFem(std::initializer_list<std::reference_wrapper<NuTo::NodeSimple>> nodes,
@@ -27,7 +26,6 @@ public:
         , mInterpolation(interpolation)
     {
         assert(static_cast<int>(mNodes.size()) == interpolation.GetNumNodes());
-        assert(mNodes.front().get().GetNumValues() == interpolation.GetDofDimension());
     }
 
     virtual NodeValues ExtractNodeValues() const override
@@ -41,8 +39,7 @@ public:
 
     NMatrix GetNMatrix(NaturalCoords ipCoords) const override
     {
-        return Matrix::N(Interpolation().GetShapeFunctions(ipCoords), Interpolation().GetNumNodes(),
-                         Interpolation().GetDofDimension());
+        return Matrix::N(Interpolation().GetShapeFunctions(ipCoords), Interpolation().GetNumNodes(), GetDofDimension());
     }
 
     ShapeFunctions GetShapeFunctions(NaturalCoords ipCoords) const override
@@ -57,7 +54,7 @@ public:
 
     int GetDofDimension() const override
     {
-        return Interpolation().GetDofDimension();
+        return GetNode(0).GetNumValues();
     }
 
     Eigen::VectorXi GetDofNumbering() const override

--- a/src/mechanics/elements/ElementInterface.h
+++ b/src/mechanics/elements/ElementInterface.h
@@ -14,7 +14,7 @@ public:
     virtual NodeValues ExtractNodeValues() const = 0;
 
     virtual int GetDofDimension() const = 0;
-    
+
     //! @brief extract the dof numbers from its nodes.
     //! @remark They have to be in the same order as defined in ExtractNodeValues()
     virtual Eigen::VectorXi GetDofNumbering() const = 0;

--- a/src/mechanics/interpolation/InterpolationQuadLinear.h
+++ b/src/mechanics/interpolation/InterpolationQuadLinear.h
@@ -7,11 +7,6 @@ namespace NuTo
 class InterpolationQuadLinear : public InterpolationSimple
 {
 public:
-    InterpolationQuadLinear(int dofDimension)
-        : mDofDimension(dofDimension)
-    {
-    }
-
     std::unique_ptr<InterpolationSimple> Clone() const override
     {
         return std::make_unique<InterpolationQuadLinear>(*this);
@@ -36,13 +31,5 @@ public:
     {
         return 4;
     }
-
-    int GetDofDimension() const override
-    {
-        return mDofDimension;
-    }
-
-private:
-    int mDofDimension;
 };
 } /* NuTo */

--- a/src/mechanics/interpolation/InterpolationQuadSerendipity.h
+++ b/src/mechanics/interpolation/InterpolationQuadSerendipity.h
@@ -7,11 +7,6 @@ namespace NuTo
 class InterpolationQuadSerendipity : public InterpolationSimple
 {
 public:
-    InterpolationQuadSerendipity(int dofDimension)
-        : mDofDimension(dofDimension)
-    {
-    }
-
     std::unique_ptr<InterpolationSimple> Clone() const override
     {
         return std::make_unique<InterpolationQuadSerendipity>(*this);
@@ -36,13 +31,5 @@ public:
     {
         return 8;
     }
-
-    int GetDofDimension() const override
-    {
-        return mDofDimension;
-    }
-
-private:
-    int mDofDimension;
 };
 } /* NuTo */

--- a/src/mechanics/interpolation/InterpolationSimple.h
+++ b/src/mechanics/interpolation/InterpolationSimple.h
@@ -34,8 +34,6 @@ public:
     //! @brief returns the number of nodes
     //! @return number of nodes
     virtual int GetNumNodes() const = 0;
-
-    virtual int GetDofDimension() const = 0;
 };
 
 //! @brief clone methods that enables a boost::ptr_container<this> to copy itself

--- a/src/mechanics/interpolation/InterpolationTetrahedronLinear.h
+++ b/src/mechanics/interpolation/InterpolationTetrahedronLinear.h
@@ -8,11 +8,6 @@ namespace NuTo
 class InterpolationTetrahedronLinear : public InterpolationSimple
 {
 public:
-    InterpolationTetrahedronLinear(int dofDimension)
-        : mDofDimension(dofDimension)
-    {
-    }
-
     std::unique_ptr<InterpolationSimple> Clone() const override
     {
         return std::make_unique<InterpolationTetrahedronLinear>(*this);
@@ -37,13 +32,5 @@ public:
     {
         return 4;
     }
-
-    int GetDofDimension() const override
-    {
-        return mDofDimension;
-    }
-
-private:
-    int mDofDimension;
 };
 } /* NuTo */

--- a/src/mechanics/interpolation/InterpolationTriangleLinear.h
+++ b/src/mechanics/interpolation/InterpolationTriangleLinear.h
@@ -8,11 +8,6 @@ namespace NuTo
 class InterpolationTriangleLinear : public InterpolationSimple
 {
 public:
-    InterpolationTriangleLinear(int dofDimension)
-        : mDofDimension(dofDimension)
-    {
-    }
-
     std::unique_ptr<InterpolationSimple> Clone() const override
     {
         return std::make_unique<InterpolationTriangleLinear>(*this);
@@ -37,13 +32,5 @@ public:
     {
         return 3;
     }
-
-    int GetDofDimension() const override
-    {
-        return mDofDimension;
-    }
-
-private:
-    int mDofDimension;
 };
 } /* NuTo */

--- a/src/mechanics/interpolation/InterpolationTriangleQuadratic.h
+++ b/src/mechanics/interpolation/InterpolationTriangleQuadratic.h
@@ -8,11 +8,6 @@ namespace NuTo
 class InterpolationTriangleQuadratic : public InterpolationSimple
 {
 public:
-    InterpolationTriangleQuadratic(int dofDimension)
-        : mDofDimension(dofDimension)
-    {
-    }
-
     std::unique_ptr<InterpolationSimple> Clone() const override
     {
         return std::make_unique<InterpolationTriangleQuadratic>(*this);
@@ -37,13 +32,5 @@ public:
     {
         return 6;
     }
-
-    int GetDofDimension() const override
-    {
-        return mDofDimension;
-    }
-
-private:
-    int mDofDimension;
 };
 } /* NuTo */

--- a/src/mechanics/interpolation/InterpolationTrussLinear.h
+++ b/src/mechanics/interpolation/InterpolationTrussLinear.h
@@ -8,11 +8,6 @@ namespace NuTo
 class InterpolationTrussLinear : public InterpolationSimple
 {
 public:
-    InterpolationTrussLinear(int dofDimension)
-        : mDofDimension(dofDimension)
-    {
-    }
-
     std::unique_ptr<InterpolationSimple> Clone() const override
     {
         return std::make_unique<InterpolationTrussLinear>(*this);
@@ -37,13 +32,5 @@ public:
     {
         return 2;
     }
-
-    int GetDofDimension() const override
-    {
-        return mDofDimension;
-    }
-
-private:
-    int mDofDimension;
 };
 } /* NuTo */

--- a/src/mechanics/mesh/UnitMeshFem.cpp
+++ b/src/mechanics/mesh/UnitMeshFem.cpp
@@ -35,7 +35,7 @@ MeshFem CreateNodes2D(int numX, int numY)
 MeshFem UnitMeshFem::CreateLines(int numX)
 {
     MeshFem mesh = CreateNodes1D(numX);
-    const auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTrussLinear(1));
+    const auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTrussLinear());
     for (int i = 0; i < numX; ++i)
     {
         auto& nl = mesh.Nodes[i];
@@ -49,7 +49,7 @@ MeshFem UnitMeshFem::CreateLines(int numX)
 MeshFem UnitMeshFem::CreateTriangles(int numX, int numY)
 {
     MeshFem mesh = CreateNodes2D(numX, numY);
-    const auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear(2));
+    const auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
     for (int iY = 0; iY < numY; ++iY)
         for (int iX = 0; iX < numX; ++iX)
         {
@@ -66,7 +66,7 @@ MeshFem UnitMeshFem::CreateTriangles(int numX, int numY)
 MeshFem UnitMeshFem::CreateQuads(int numX, int numY)
 {
     MeshFem mesh = CreateNodes2D(numX, numY);
-    const auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationQuadLinear(2));
+    const auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationQuadLinear());
     for (int iY = 0; iY < numY; ++iY)
         for (int iX = 0; iX < numX; ++iX)
         {

--- a/test/mechanics/cell/Cell.cpp
+++ b/test/mechanics/cell/Cell.cpp
@@ -19,14 +19,14 @@ BOOST_AUTO_TEST_CASE(CellLetsSee)
     // const double lz = 1; // requires something like "Section" ...
     const double E = 6174;
 
-    NuTo::InterpolationQuadLinear interpolationCoordinates(2);
+    NuTo::InterpolationQuadLinear interpolationCoordinates;
     NuTo::NodeSimple nCoord0(Eigen::Vector2d({0, 0}));
     NuTo::NodeSimple nCoord1(Eigen::Vector2d({lx, 0}));
     NuTo::NodeSimple nCoord2(Eigen::Vector2d({lx, ly}));
     NuTo::NodeSimple nCoord3(Eigen::Vector2d({0, ly}));
     NuTo::ElementFem coordinateElement({nCoord0, nCoord1, nCoord2, nCoord3}, interpolationCoordinates);
 
-    NuTo::InterpolationQuadLinear interpolationDisplacements(2);
+    NuTo::InterpolationQuadLinear interpolationDisplacements;
     NuTo::NodeSimple nDispl0(Eigen::Vector2d({0, 0}));
     NuTo::NodeSimple nDispl1(Eigen::Vector2d({0, 0}));
     NuTo::NodeSimple nDispl2(Eigen::Vector2d({0, 0}));

--- a/test/mechanics/cell/CreepLaw.cpp
+++ b/test/mechanics/cell/CreepLaw.cpp
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(History_Data)
     //                                          [](Eigen::VectorXd vec) { return SpecimenLength * vec; });
 
     DofType displ("displacements", 1);
-    const auto& interpolation = mesh.CreateInterpolation(InterpolationTrussLinear(1));
+    const auto& interpolation = mesh.CreateInterpolation(InterpolationTrussLinear());
     AddDofInterpolation(&mesh, displ, interpolation);
 
 

--- a/test/mechanics/cell/PatchTest.cpp
+++ b/test/mechanics/cell/PatchTest.cpp
@@ -76,7 +76,7 @@ MeshFem QuadPatchTestMesh()
     NodeSimple& n6 = mesh.Nodes.Add(Eigen::Vector2d(8, 7));
     NodeSimple& n7 = mesh.Nodes.Add(Eigen::Vector2d(4, 7));
 
-    const InterpolationSimple& interpolation = mesh.CreateInterpolation(InterpolationQuadLinear(2));
+    const InterpolationSimple& interpolation = mesh.CreateInterpolation(InterpolationQuadLinear());
 
     mesh.Elements.Add({{{n0, n1, n5, n4}, interpolation}});
     mesh.Elements.Add({{{n1, n2, n6, n5}, interpolation}});
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(PatchTestForce)
 {
     MeshFem mesh = QuadPatchTestMesh();
     DofType displ("displacements", 2);
-    const InterpolationSimple& interpolation = mesh.CreateInterpolation(InterpolationQuadLinear(2));
+    const InterpolationSimple& interpolation = mesh.CreateInterpolation(InterpolationQuadLinear());
 
     AddDofInterpolation(&mesh, displ, interpolation);
 
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(PatchTestForce)
     // ************************************************************************
 
     // manually add the boundary element
-    const InterpolationSimple& interpolationBc = mesh.CreateInterpolation(InterpolationTrussLinear(2));
+    const InterpolationSimple& interpolationBc = mesh.CreateInterpolation(InterpolationTrussLinear());
 
     // extract existing nodes
     Group<NodeSimple> boundaryCoordNodes = mesh.NodesAtAxis(eDirection::X, 10);
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(PatchTestDispl)
 {
     MeshFem mesh = QuadPatchTestMesh();
     DofType displ("displacements", 2);
-    const auto& interpolation = mesh.CreateInterpolation(InterpolationQuadLinear(2));
+    const auto& interpolation = mesh.CreateInterpolation(InterpolationQuadLinear());
 
     AddDofInterpolation(&mesh, displ, interpolation);
 

--- a/test/mechanics/elements/ElementCollection.cpp
+++ b/test/mechanics/elements/ElementCollection.cpp
@@ -5,10 +5,10 @@
 
 BOOST_AUTO_TEST_CASE(ElementCollectionAccess)
 {
-    NuTo::NodeSimple n0(Eigen::Vector2d(0,0));
-    NuTo::NodeSimple n1(Eigen::Vector2d(0,0));
-    NuTo::NodeSimple n2(Eigen::Vector2d(0,0));
-    NuTo::InterpolationTriangleLinear interpolation(2);
+    NuTo::NodeSimple n0(Eigen::Vector2d(0, 0));
+    NuTo::NodeSimple n1(Eigen::Vector2d(0, 0));
+    NuTo::NodeSimple n2(Eigen::Vector2d(0, 0));
+    NuTo::InterpolationTriangleLinear interpolation;
 
 
     NuTo::ElementCollectionFem elements(NuTo::ElementFem({n0, n1, n2}, interpolation));
@@ -18,4 +18,3 @@ BOOST_AUTO_TEST_CASE(ElementCollectionAccess)
     BOOST_CHECK_EQUAL(cellElements.CoordinateElement().GetDofDimension(), 2);
     BOOST_CHECK_EQUAL(cellElements.CoordinateElement().GetNumNodes(), 3);
 }
-

--- a/test/mechanics/elements/ElementFem.cpp
+++ b/test/mechanics/elements/ElementFem.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(ElementCopyMove)
 NuTo::NodeSimple n0 = NuTo::NodeSimple(Eigen::Vector2d({1, 1}));
 NuTo::NodeSimple n1 = NuTo::NodeSimple(Eigen::Vector2d({5, 1}));
 NuTo::NodeSimple n2 = NuTo::NodeSimple(Eigen::Vector2d({1, 7}));
-NuTo::InterpolationTriangleLinear interpolation = NuTo::InterpolationTriangleLinear(2);
+NuTo::InterpolationTriangleLinear interpolation;
 
 NuTo::ElementFem TestElement()
 {

--- a/test/mechanics/integrands/HistoryData.cpp
+++ b/test/mechanics/integrands/HistoryData.cpp
@@ -47,7 +47,7 @@ public:
 
 BOOST_AUTO_TEST_CASE(Pass_Data_To_Integrand)
 {
-    InterpolationTrussLinear interpolation(1);
+    InterpolationTrussLinear interpolation;
     NodeSimple n0(0);
     NodeSimple n1(42);
     ElementFem coordinateElement({n0, n1}, interpolation);

--- a/test/mechanics/integrands/NeumannBc.cpp
+++ b/test/mechanics/integrands/NeumannBc.cpp
@@ -20,14 +20,14 @@ BOOST_AUTO_TEST_CASE(NeumannBc1Din2D)
     // coordinate element
     NodeSimple nc0(Eigen::Vector2d(0, 0));
     NodeSimple nc1(Eigen::Vector2d(2, 2));
-    InterpolationTrussLinear coordinateInterpolation(2);
+    InterpolationTrussLinear coordinateInterpolation;
     ElementCollectionFem element({{nc0, nc1}, coordinateInterpolation});
 
     // displacement nodes
     DofType dof("displacements", 2);
     NodeSimple nd0(Eigen::Vector2d(0, 0));
     NodeSimple nd1(Eigen::Vector2d(0, 0));
-    InterpolationTrussLinear displacementInterpolation(2);
+    InterpolationTrussLinear displacementInterpolation;
     element.AddDofElement(dof, {{nd0, nd1}, displacementInterpolation});
 
     Eigen::Vector2d p(4, 42);
@@ -100,12 +100,12 @@ BOOST_AUTO_TEST_CASE(NeumannBc2Din3D)
     nodesDispPtrs.push_back(&nodesDisp[2]);
 
     // coordinate element
-    InterpolationTriangleLinear coordinateInterpolation(3);
+    InterpolationTriangleLinear coordinateInterpolation;
     ElementCollectionFem element({nodePtrs, coordinateInterpolation});
 
     // displacement nodes
     DofType dof("displacements", 3);
-    InterpolationTriangleLinear displacementInterpolation(3);
+    InterpolationTriangleLinear displacementInterpolation;
     element.AddDofElement(dof, {nodesDispPtrs, displacementInterpolation});
 
     Eigen::Vector3d p(1., 1., 1.);

--- a/test/mechanics/mesh/MeshFem.cpp
+++ b/test/mechanics/mesh/MeshFem.cpp
@@ -12,8 +12,7 @@ void SetStuff(NuTo::MeshFem& m)
 NuTo::MeshFem DummyMesh(NuTo::DofType dofType)
 {
     NuTo::MeshFem mesh;
-    auto& interpolationCoords = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear(2));
-    auto& interpolationDof = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear(dofType.GetNum()));
+    auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
 
     auto& n0 = mesh.Nodes.Add(Eigen::Vector2d({1, 0}));
     auto& n1 = mesh.Nodes.Add(Eigen::Vector2d({2, 0}));
@@ -23,8 +22,8 @@ NuTo::MeshFem DummyMesh(NuTo::DofType dofType)
     auto& nd1 = mesh.Nodes.Add(4);
     auto& nd2 = mesh.Nodes.Add(6174);
 
-    auto& e0 = mesh.Elements.Add({{{n0, n1, n2}, interpolationCoords}});
-    e0.AddDofElement(dofType, {{nd0, nd1, nd2}, interpolationDof});
+    auto& e0 = mesh.Elements.Add({{{n0, n1, n2}, interpolation}});
+    e0.AddDofElement(dofType, {{nd0, nd1, nd2}, interpolation});
     return mesh;
 }
 
@@ -117,9 +116,9 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
     auto& n2 = mesh.Nodes.Add(Eigen::Vector2d(0, 1));
     auto& n3 = mesh.Nodes.Add(Eigen::Vector2d(1, 1));
 
-    auto& interpolationCoords = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear(2));
-    mesh.Elements.Add({{{n0, n1, n2}, interpolationCoords}});
-    mesh.Elements.Add({{{n1, n3, n2}, interpolationCoords}});
+    auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
+    mesh.Elements.Add({{{n0, n1, n2}, interpolation}});
+    mesh.Elements.Add({{{n1, n3, n2}, interpolation}});
 
     int expectedNumCoordinateNodes = 4;
     BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumCoordinateNodes);
@@ -127,9 +126,8 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
 
     // add linear dof type
 
-    const auto& interpolationLinear = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear(1));
     NuTo::DofType dof0("linear", 1);
-    NuTo::AddDofInterpolation(&mesh, dof0, interpolationLinear);
+    NuTo::AddDofInterpolation(&mesh, dof0, interpolation);
 
     int expectedNumDof0Nodes = expectedNumCoordinateNodes; // same interpolation
 
@@ -150,7 +148,7 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
      * The numbering is not correct, but the total number of points is.
      */
     NuTo::DofType dof1("quadratic", 1);
-    const auto& interpolationQuadratic = mesh.CreateInterpolation(NuTo::InterpolationTriangleQuadratic(1));
+    const auto& interpolationQuadratic = mesh.CreateInterpolation(NuTo::InterpolationTriangleQuadratic());
     NuTo::AddDofInterpolation(&mesh, dof1, interpolationQuadratic);
 
     int expectedNumDof1Nodes = 9;

--- a/test/tools/InterpolationTests.h
+++ b/test/tools/InterpolationTests.h
@@ -63,7 +63,7 @@ void CheckShapeFunctionsAndNodePositions(const NuTo::InterpolationSimple& r)
 template <typename T>
 void RunTests(const std::vector<Eigen::VectorXd>& rPoints)
 {
-    T interpolation(1);
+    T interpolation;
 
     BOOST_TEST_MESSAGE("Checking copy move...");
     CheckCopyMove<T>();


### PR DESCRIPTION
Solves #142.

The only place where there the dof dimension is needed is the calculation of the `N` matrix. This dimension is now extracted from the first node of the element, namely the `NodeSimple::GetNumValues()`.