### PR TITLE
Pde docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,12 @@ notifications:
         on_success: change  # always|never|change
         on_failure: always
         on_start: never
-matrix:
-    include:
-        - compiler: clang
-          env: BUILD_TYPE=Release OPENMP=TRUE
-        - compiler: g++
-          env: BUILD_TYPE=Release OPENMP=FALSE
-          env: BUILD_TYPE=Release OPENMP=TRUE
-          env: BUILD_TYPE=Debug OPENMP=FALSE COVERAGE=--coverage
+
+env:
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=FALSE"
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=FALSE"
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=TRUE"
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENMP=FALSE -DCMAKE_CXX_FLAGS=--coverage"
 
 before_install:
     - ci_env=`bash <(curl -s https://codecov.io/env)`
@@ -26,7 +24,7 @@ before_install:
 script:
     # - We log in /home/nuto (set as WORKDIR in Dockerfile). This will be our build directory avoid changing directories.
     # - The source code from travis is 'mounted' as /home/nuto/source via the -v option in the docker run command above
-    - docker exec dock cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_OPENMP=$OPENMP -DCMAKE_CXX_FLAGS=$COVERAGE  source
+    - docker exec dock cmake $BUILD_OPTIONS source
     - docker exec dock make -j2 unit
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,7 @@ language: cpp
 sudo: false
 services: docker
 dist: trusty
-notifications:
-    webhooks:
-        urls:
-            - "https://scalar.vector.im/api/neb/services/hooks/dHJhdmlzLWNpLyU0MFBzaXJ1cyUzQW1hdHJpeC5vcmcvJTIxZG9KWEFCclp5VVBlV0Jmb0ZYJTNBbWF0cml4Lm9yZw"
-        on_success: change  # always|never|change
-        on_failure: always
-        on_start: never
+
 matrix:
     include:
         - compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,9 @@ matrix:
           env: BUILD_TYPE=Debug OPENMP=FALSE COVERAGE=--coverage
 
 before_install:
-    - ci_env=`bash <(curl -s https://codecov.io/env)`
-    - echo $ci_env
+    - CI_ENV=`bash <(curl -s https://codecov.io/env)`
     - travis_retry docker pull nuto/nuto_docker:xenial
-    - docker run $ci_env -itd --user nuto --name dock -v $(pwd):/home/nuto/source nuto/nuto_docker:xenial
+    - docker run $CI_ENV -itd --user nuto --name dock -v $(pwd):/home/nuto/source nuto/nuto_docker:xenial
 
 script:
     # - We log in /home/nuto (set as WORKDIR in Dockerfile). This will be our build directory avoid changing directories.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,16 @@ notifications:
         on_success: change  # always|never|change
         on_failure: always
         on_start: never
-
-env:
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=FALSE"
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=FALSE"
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=TRUE"
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENMP=FALSE -DCMAKE_CXX_FLAGS=--coverage"
+matrix:
+    include:
+        - compiler: clang
+          env: BUILD_TYPE=Release OPENMP=FALSE
+        - compiler: g++
+          env: BUILD_TYPE=Release OPENMP=FALSE
+        - compiler: g++
+          env: BUILD_TYPE=Release OPENMP=TRUE
+        - compiler: g++
+          env: BUILD_TYPE=Debug OPENMP=FALSE COVERAGE=--coverage
 
 before_install:
     - ci_env=`bash <(curl -s https://codecov.io/env)`
@@ -24,7 +28,7 @@ before_install:
 script:
     # - We log in /home/nuto (set as WORKDIR in Dockerfile). This will be our build directory avoid changing directories.
     # - The source code from travis is 'mounted' as /home/nuto/source via the -v option in the docker run command above
-    - docker exec dock cmake $BUILD_OPTIONS source
+    - docker exec dock cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_OPENMP=$OPENMP -DCMAKE_CXX_FLAGS=$COVERAGE source
     - docker exec dock make -j2 unit
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,13 @@ before_install:
     - ci_env=`bash <(curl -s https://codecov.io/env)`
     - echo $ci_env
     - docker pull nuto/nuto_docker:v2
-    - docker run $ci_env -itd --name dock -v $(pwd):/project nuto/nuto_docker:v2
+    - docker run $ci_env -itd --user nuto --name dock -v $(pwd):/home/nuto/source nuto/nuto_docker:v3
 
 script:
-    - docker exec dock cmake $BUILD_OPTIONS .
+    # - We log in /home/nuto (set as WORKDIR in Dockerfile). This will be our build directory avoid changing directories.
+    # - The source code from travis is 'mounted' as /home/nuto/source via the -v option in the docker run command above
+    - docker exec dock cmake $BUILD_OPTIONS source
     - docker exec dock make -j2 unit
 
 after_success:
-    - docker exec dock bash scripts/upload_coverage.sh # will simply fail if --coverage is not set.
+    - docker exec dock bash source/scripts/upload_coverage.sh # will simply fail if --coverage is not set.

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
 before_install:
     - ci_env=`bash <(curl -s https://codecov.io/env)`
     - echo $ci_env
+    - travis_retry docker pull nuto/nuto_docker:xenial
     - docker run $ci_env -itd --user nuto --name dock -v $(pwd):/home/nuto/source nuto/nuto_docker:xenial
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ script:
     # - The source code from travis is 'mounted' as /home/nuto/source via the -v option in the docker run command above
     - docker exec dock cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_OPENMP=$OPENMP -DCMAKE_CXX_FLAGS=$COVERAGE source
     - docker exec dock make -j2 unit
+    - docker exec dock make -j2
+    - docker exec dock bash source/scripts/check_install.sh
 
 after_success:
     - docker exec dock bash source/scripts/upload_coverage.sh # will simply fail if --coverage is not set.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
-sudo: required
+sudo: false
+services: docker
 dist: trusty
 notifications:
     webhooks:
@@ -8,49 +9,24 @@ notifications:
         on_success: change  # always|never|change
         on_failure: always
         on_start: never
+compiler:
+    - gcc
 
-jobs:
-    include:
-        - stage: normal builds
-          env: BUILD_TYPE=Release OPENMP=FALSE
-          compiler: clang
-        - env: BUILD_TYPE=Release OPENMP=TRUE
-          compiler: gcc
-        - env: BUILD_TYPE=Release OPENMP=FALSE
-          compiler: gcc
-        - env: BUILD_TYPE=Debug   OPENMP=FALSE COVERAGE=--coverage
-          compiler: gcc
-        - stage: compiler warnings
-          env: BUILD_TYPE=Debug   OPENMP=FALSE WERROR=-Werror
-          compiler: gcc
-        - env: BUILD_TYPE=Debug   OPENMP=FALSE WERROR=-Werror
-          compiler: clang
-        - env: BUILD_TYPE=Release   OPENMP=FALSE WERROR=-Werror
-          compiler: gcc
-        - env: BUILD_TYPE=Release   OPENMP=FALSE WERROR=-Werror
-          compiler: clang
-    allow_failures:
-        - env: BUILD_TYPE=Debug   OPENMP=FALSE WERROR=-Werror
-        - env: BUILD_TYPE=Release   OPENMP=FALSE WERROR=-Werror
-    fast_finish: true
+env:
+    - BUILD_TYPE=Debug OPENMP=FALSE COVERAGE=--coverage
 
 before_install:
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - ./scripts/install_numpy.sh
-    - ./scripts/install_gmsh.sh
-    - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-    - sudo apt-get -qq update
-    - sudo apt-get -qq install -y g++-6 clang libeigen3-dev libgcc-6-dev libiomp-dev swig3.0 libboost-filesystem1.55-dev libboost-test1.55-dev libboost-mpi1.55-dev libopenblas-dev libmetis-dev libmumps-seq-dev libann-dev libarpack2-dev lcov curl libglu1-mesa-dev
-before_script:
-    - mkdir build
-    - cd build
-    - BUILD_OPTIONS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_OPENMP=$OPENMP -DENABLE_MPI=TRUE"
-    - if [[ "$CXX" == "g++" ]]; then CXX=g++-6 cmake $BUILD_OPTIONS -DCMAKE_CXX_FLAGS="$COVERAGE $WERROR" ..; fi
-    - if [[ "$CXX" == "clang++" ]]; then CXX=clang++ cmake $BUILD_OPTIONS -DCMAKE_CXX_FLAGS="$COVERAGE $WERROR" ..; fi
+    - ci_env=`bash <(curl -s https://codecov.io/env)`
+    - echo $ci_env
+
+    - docker pull nuto/nuto_docker:v2
+    - docker run $ci_env -itd --name dock -v $(pwd):/project nuto/nuto_docker:v2
+
 script:
-    - make -j2 unit
-    - sudo make install
-    - cd ..
-    - ./scripts/check_install.sh
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=/usr/bin/g++-6 -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_OPENMP=$OPENMP -DCMAKE_CXX_FLAGS=$COVERAGE"
+    #- docker exec dock mkdir build && cd build
+    - docker exec dock cmake $BUILD_OPTIONS .
+    - docker exec dock make -j2 unit
 after_success:
-    - ./scripts/upload_coverage.sh
+    #- docker exec dock cd ..
+    - docker exec dock bash scripts/upload_coverage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,14 @@ notifications:
         on_success: change  # always|never|change
         on_failure: always
         on_start: never
-
-env:
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=FALSE"
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=FALSE"
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=TRUE"
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENMP=FALSE -DCMAKE_CXX_FLAGS=--coverage"
+matrix:
+    include:
+        - compiler: clang
+          env: BUILD_TYPE=Release OPENMP=TRUE
+        - compiler: g++
+          env: BUILD_TYPE=Release OPENMP=FALSE
+          env: BUILD_TYPE=Release OPENMP=TRUE
+          env: BUILD_TYPE=Debug OPENMP=FALSE COVERAGE=--coverage
 
 before_install:
     - ci_env=`bash <(curl -s https://codecov.io/env)`
@@ -24,7 +26,7 @@ before_install:
 script:
     # - We log in /home/nuto (set as WORKDIR in Dockerfile). This will be our build directory avoid changing directories.
     # - The source code from travis is 'mounted' as /home/nuto/source via the -v option in the docker run command above
-    - docker exec dock cmake $BUILD_OPTIONS source
+    - docker exec dock cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_OPENMP=$OPENMP -DCMAKE_CXX_FLAGS=$COVERAGE  source
     - docker exec dock make -j2 unit
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,24 +9,22 @@ notifications:
         on_success: change  # always|never|change
         on_failure: always
         on_start: never
-compiler:
-    - gcc
 
 env:
-    - BUILD_TYPE=Debug OPENMP=FALSE COVERAGE=--coverage
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=clang++-4.0 -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=FALSE"
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++-6 -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=FALSE"
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++-6 -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=TRUE"
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++-6 -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENMP=FALSE -DCMAKE_CXX_FLAGS=--coverage"
 
 before_install:
     - ci_env=`bash <(curl -s https://codecov.io/env)`
     - echo $ci_env
-
     - docker pull nuto/nuto_docker:v2
     - docker run $ci_env -itd --name dock -v $(pwd):/project nuto/nuto_docker:v2
 
 script:
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=/usr/bin/g++-6 -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_OPENMP=$OPENMP -DCMAKE_CXX_FLAGS=$COVERAGE"
-    #- docker exec dock mkdir build && cd build
     - docker exec dock cmake $BUILD_OPTIONS .
     - docker exec dock make -j2 unit
+
 after_success:
-    #- docker exec dock cd ..
-    - docker exec dock bash scripts/upload_coverage.sh
+    - docker exec dock bash scripts/upload_coverage.sh # will simply fail if --coverage is not set.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,15 @@ notifications:
         on_start: never
 
 env:
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=clang++-4.0 -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=FALSE"
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++-6 -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=FALSE"
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++-6 -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=TRUE"
-    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++-6 -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENMP=FALSE -DCMAKE_CXX_FLAGS=--coverage"
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=FALSE"
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=FALSE"
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=TRUE"
+    - BUILD_OPTIONS="-DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENMP=FALSE -DCMAKE_CXX_FLAGS=--coverage"
 
 before_install:
     - ci_env=`bash <(curl -s https://codecov.io/env)`
     - echo $ci_env
-    - docker pull nuto/nuto_docker:v2
-    - docker run $ci_env -itd --user nuto --name dock -v $(pwd):/home/nuto/source nuto/nuto_docker:v3
+    - docker run $ci_env -itd --user nuto --name dock -v $(pwd):/home/nuto/source nuto/nuto_docker:xenial
 
 script:
     # - We log in /home/nuto (set as WORKDIR in Dockerfile). This will be our build directory avoid changing directories.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(ENABLE_CUSTOM_EXAMPLES
     "enable private examples in separate directory (applications/custom)" FALSE)
 option(ENABLE_OPENMP "enables OpenMP" FALSE)
 option(ENABLE_PARDISO "enables support for PARDISO solver" FALSE)
-option(ENABLE_PYTHON "create python wrapper for nuto" TRUE)
+option(ENABLE_PYTHON "create python wrapper for nuto" FALSE)
 option(ENABLE_MPI "enables message passing interface" FALSE)
 
 # set module path for custom cmake scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get install -y g++ clang cmake
 RUN apt-get install -y libboost-filesystem-dev libboost-system-dev libboost-mpi-dev libboost-test-dev
 
 # Nuto deps
-RUN apt-get install -y libeigen3-dev libiomp-dev swig3.0 doxygen python3-dev python3-numpy libopenblas-dev libmetis-dev libmumps-seq-dev libann-dev libarpack2-dev gmsh 
+RUN apt-get install -y libeigen3-dev libiomp-dev python3-dev python3-numpy libopenblas-dev libmetis-dev libmumps-seq-dev libann-dev libarpack2-dev gmsh 
 
 # coverage and documentation
-RUN apt-get install -y lcov curl texlive-font-utils
+RUN apt-get install -y lcov curl 
 
 #fix missing /dev/fd from https://github.com/jbbarth/docker-ruby/commit/1916309122b7c04be4c01c46910471fc1d8176c6
 RUN test -e /dev/fd || ln -s /proc/self/fd /dev/fd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,14 @@
-FROM ubuntu
-RUN apt-get -qq update
-RUN apt-get install -y software-properties-common
-RUN apt-get -qq update
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y
-RUN apt-get -qq update
+FROM ubuntu:xenial
 
+RUN apt-get update && apt-get dist-upgrade -y
 # Toolchain?
-RUN apt-get install -y --fix-missing cmake
-RUN apt-get install -y g++-6
-RUN apt-get install -y clang++-4.0
-# Nuto deps
-RUN apt-get install -y libeigen3-dev libiomp-dev swig3.0 doxygen python3-dev python3-numpy libopenblas-dev libmetis-dev libmumps-seq-dev libann-dev libarpack2-dev gmsh 
+RUN apt-get install -y g++ clang cmake
 # boost
 RUN apt-get install -y libboost-filesystem-dev libboost-system-dev libboost-mpi-dev libboost-test-dev
+
+# Nuto deps
+RUN apt-get install -y libeigen3-dev libiomp-dev swig3.0 doxygen python3-dev python3-numpy libopenblas-dev libmetis-dev libmumps-seq-dev libann-dev libarpack2-dev gmsh 
+
 # coverage and documentation
 RUN apt-get install -y lcov curl texlive-font-utils
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu
+RUN apt-get -qq update
+RUN apt-get install -y software-properties-common
+RUN apt-get -qq update
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y
+RUN apt-get -qq update
+
+# Toolchain?
+RUN apt-get install -y --fix-missing cmake
+RUN apt-get install -y g++-6
+RUN apt-get install -y clang++-4.0
+# Nuto deps
+RUN apt-get install -y libeigen3-dev libiomp-dev swig3.0 doxygen python3-dev python3-numpy libopenblas-dev libmetis-dev libmumps-seq-dev libann-dev libarpack2-dev gmsh 
+# boost
+RUN apt-get install -y libboost-filesystem-dev libboost-system-dev libboost-mpi-dev libboost-test-dev
+# coverage and documentation
+RUN apt-get install -y lcov curl texlive-font-utils
+
+#fix missing /dev/fd from https://github.com/jbbarth/docker-ruby/commit/1916309122b7c04be4c01c46910471fc1d8176c6
+RUN test -e /dev/fd || ln -s /proc/self/fd /dev/fd
+
+# setup non root user named nuto with sudo rights, following the instructions from
+# https://stackoverflow.com/questions/25845538/using-sudo-inside-a-docker-container
+RUN apt-get install -y sudo
+RUN useradd nuto && echo "nuto:nuto" | chpasswd && adduser nuto sudo
+RUN mkdir -p /home/nuto && chown -R nuto:nuto /home/nuto
+USER nuto
+
+# create the source directory /home/nuto/source
+RUN mkdir /home/nuto/source
+
+# the build directory will be in /home/nuto 
+WORKDIR /home/nuto

--- a/scripts/check_install.sh
+++ b/scripts/check_install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -ev
+echo nuto | sudo -S make install
 mkdir -p testproject && cd testproject
 printf "project(testproject)\ncmake_minimum_required(VERSION 3.5)\nset(CMAKE_CXX_STANDARD 14)\nfind_package(NuTo)\nadd_executable(printVersion printVersion.cpp)\ntarget_link_libraries(printVersion NuTo::Base NuTo::Mechanics)" > CMakeLists.txt
 printf "#include <iostream>\n#include <nuto/base/Version.h>\nint main(){\nstd::cout << NuTo::Version << std::endl;\nreturn 0;\n}" > printVersion.cpp

--- a/scripts/get_numpy_path.py
+++ b/scripts/get_numpy_path.py
@@ -1,3 +1,0 @@
-#!/usr/bin/env python3
-import numpy.distutils as nd
-print(nd.misc_util.get_numpy_include_dirs()[0])

--- a/scripts/install_gmsh.sh
+++ b/scripts/install_gmsh.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -ev
-# 2.8.5 is the version in debian stable
-wget -q http://gmsh.info/bin/Linux/gmsh-2.8.5-Linux64.tgz
-tar xf gmsh-2.8.5-Linux64.tgz
-sudo cp gmsh-2.8.5-Linux/bin/gmsh /usr/bin

--- a/scripts/install_numpy.sh
+++ b/scripts/install_numpy.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -ev
-wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-chmod +x miniconda.sh
-bash miniconda.sh -b -p $HOME/miniconda
-conda install --yes --quiet numpy

--- a/scripts/upload_coverage.sh
+++ b/scripts/upload_coverage.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -ev
-if [[ "$COVERAGE" == "--coverage" ]]; then
+#if [[ "$COVERAGE" == "--coverage" ]]; then
     # get coverage information
-    lcov --capture --directory build --output-file coverage.info 2> /dev/null
+    lcov --capture --directory . --output-file coverage.info # 2> /dev/null
     # filter out system stuff that we don't control
     lcov -r coverage.info '/usr/include/*' -o coverage.info
     # filter out external libraries
     EXTERNALFILES="$(pwd)/external/*"
     lcov -r coverage.info "$EXTERNALFILES" -o coverage.info
     # upload to codecov
-    bash <(curl -s https://codecov.io/bash) -f coverage.info > /dev/null 2> /dev/null
-fi
+    bash <(curl -s https://codecov.io/bash) -f coverage.info # > /dev/null 2> /dev/null
+#fi

--- a/scripts/upload_coverage.sh
+++ b/scripts/upload_coverage.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 set -ev
-#if [[ "$COVERAGE" == "--coverage" ]]; then
-    # get coverage information
-    lcov --capture --directory . --output-file coverage.info # 2> /dev/null
-    # filter out system stuff that we don't control
-    lcov -r coverage.info '/usr/include/*' -o coverage.info
-    # filter out external libraries
-    EXTERNALFILES="$(pwd)/external/*"
-    lcov -r coverage.info "$EXTERNALFILES" -o coverage.info
-    # upload to codecov
-    bash <(curl -s https://codecov.io/bash) -f coverage.info # > /dev/null 2> /dev/null
-#fi
+# get coverage information
+lcov --capture --directory . --output-file coverage.info # 2> /dev/null
+# filter out system stuff that we don't control
+lcov -r coverage.info '/usr/include/*' -o coverage.info
+# filter out external libraries
+EXTERNALFILES="$(pwd)/external/*"
+lcov -r coverage.info "$EXTERNALFILES" -o coverage.info
+# upload to codecov
+bash <(curl -s https://codecov.io/bash) -f coverage.info # > /dev/null 2> /dev/null

--- a/scripts/upload_docker.sh
+++ b/scripts/upload_docker.sh
@@ -1,0 +1,3 @@
+sudo docker build -t nuto_docker .
+sudo docker tag nuto_docker nuto/nuto_docker:v3
+sudo docker push nuto/nuto_docker:v3

--- a/scripts/upload_docker.sh
+++ b/scripts/upload_docker.sh
@@ -1,3 +1,3 @@
 sudo docker build -t nuto_docker .
-sudo docker tag nuto_docker nuto/nuto_docker:v3
-sudo docker push nuto/nuto_docker:v3
+sudo docker tag nuto_docker nuto/nuto_docker:xenial
+sudo docker push nuto/nuto_docker:xenial

--- a/scripts/upload_docker.sh
+++ b/scripts/upload_docker.sh
@@ -1,3 +1,3 @@
-sudo docker build -t nuto_docker .
-sudo docker tag nuto_docker nuto/nuto_docker:xenial
-sudo docker push nuto/nuto_docker:xenial
+docker build -t nuto_docker .
+docker tag nuto_docker nuto/nuto_docker:xenial
+docker push nuto/nuto_docker:xenial

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 unset(all_unit_tests CACHE)
 
-add_subdirectory(base)
+#add_subdirectory(base)
 add_subdirectory(math)
-add_subdirectory(mechanics)
-add_subdirectory(visualize)
+#add_subdirectory(mechanics)
+#add_subdirectory(visualize)
 
 add_custom_target(unit
     COMMAND ctest -R unit --output-on-failure

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 unset(all_unit_tests CACHE)
 
-#add_subdirectory(base)
+add_subdirectory(base)
 add_subdirectory(math)
-#add_subdirectory(mechanics)
-#add_subdirectory(visualize)
+add_subdirectory(mechanics)
+add_subdirectory(visualize)
 
 add_custom_target(unit
     COMMAND ctest -R unit --output-on-failure

--- a/test/base/serializeStream/SerializeStream.cpp
+++ b/test/base/serializeStream/SerializeStream.cpp
@@ -275,7 +275,8 @@ BOOST_AUTO_TEST_CASE(SerializeVectorCompoundDataBinary)
 
 BOOST_AUTO_TEST_CASE(SerializeInvalidWrite)
 {
-    BOOST_CHECK_THROW(NuTo::SerializeStreamOut("/home/ME_WANTS_TO_WRITE_HERE.dat", true), NuTo::Exception);
+    BOOST_CHECK_THROW(NuTo::SerializeStreamOut("/home/non_existing_directory/ME_WANTS_TO_WRITE_HERE.dat", true),
+                      NuTo::Exception);
 }
 
 BOOST_AUTO_TEST_CASE(SerializeInvalidRead)


### PR DESCRIPTION
Basically solves #64 

- Travis provides ubuntu 14.04 which is outdated
- we need custom install scripts
- we cannot reproduce the travis runs

Docker container offer a nice solution. We now have a [Dockerfile](https://github.com/nutofem/nuto/blob/PDE_docker/Dockerfile) that defines something like an ubuntu virtual machine with all our dependencies. This image is uploaded to [dockerhub](https://hub.docker.com/r/nuto/nuto_docker/) and provides all the benefits of the docker service: You can run that image locally, on a server somewhere, and on travis. 

We can even create a docker container that already has nuto installed. For tutorials or whatever... another issue.
  
__edit:__
- I guess the coverage dropped because I set ENABLE_PYTHON=FALSE
- if you want do perform changes to the docker container, you have to adapt the `Dockerfile` and run `sudo bash /scripts/upload.docker.sh`