### PR TITLE
Use timeout when pulling the docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 
 before_install:
     - CI_ENV=`bash <(curl -s https://codecov.io/env)`
-    - travis_retry docker pull nuto/nuto_docker:dev
+    - travis_retry timeout 200 docker pull nuto/nuto_docker:dev
     - docker run $CI_ENV -itd --user nuto --name dock -v $(pwd):/home/nuto/source nuto/nuto_docker:dev
 
 script:


### PR DESCRIPTION
Travis sometimes fails when Docker doesn't pull correctly for some reason. This should now be prevented by automatically trying again.