### PR TITLE
Add quadratic line element

### DIFF
--- a/test/mechanics/mesh/CMakeLists.txt
+++ b/test/mechanics/mesh/CMakeLists.txt
@@ -15,6 +15,7 @@ foreach(inputFile
     triangle1.msh
     triangle2.msh
     line1.msh
+    line2.msh
     tet1.msh
     hex1.msh
     prism1.msh
@@ -25,4 +26,5 @@ endforeach()
 
 add_unit_test(MeshGmsh
     mechanics/mesh/MeshFem
+    math/Legendre
     mechanics/elements/ElementShapeFunctions)

--- a/test/mechanics/mesh/MeshGmsh.cpp
+++ b/test/mechanics/mesh/MeshGmsh.cpp
@@ -1,5 +1,6 @@
 #include "mechanics/mesh/MeshGmsh.h"
 #include "BoostUnitTest.h"
+#include "mechanics/cell/Jacobian.h"
 
 using namespace NuTo;
 
@@ -25,7 +26,23 @@ void CheckMesh(std::string meshFile, int numNodesExpected)
     MeshGmsh m(meshFile);
     auto& meshFem = m.GetMeshFEM();
     BOOST_CHECK_EQUAL(meshFem.Nodes.Size(), numNodesExpected);
-    BOOST_CHECK_EQUAL(meshFem.Elements.begin()->CoordinateElement().Interpolation().GetNumNodes(), numNodesExpected);
+    const ElementFem& element = meshFem.Elements.begin()->CoordinateElement();
+    const auto& interpolation = element.Interpolation();
+    BOOST_CHECK_EQUAL(interpolation.GetNumNodes(), numNodesExpected);
+
+    // check for constistent (same sign for all IP) Det(Jacobian)
+    bool isPositive = true;
+    for (int iNode = 0; iNode < interpolation.GetNumNodes(); ++iNode)
+    {
+        auto coord = interpolation.GetLocalCoords(iNode);
+        int globalDimension = coord.rows();
+        Jacobian j(element.ExtractNodeValues(), interpolation.GetDerivativeShapeFunctions(coord), globalDimension);
+        bool isPositiveForINode = j.Det() > -1.e-10;
+        if (iNode == 0)
+            isPositive = isPositiveForINode;
+        else
+            BOOST_CHECK(isPositive == isPositiveForINode);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(BinaryImport)
@@ -61,6 +78,11 @@ BOOST_AUTO_TEST_CASE(TriangleQuadratic)
 BOOST_AUTO_TEST_CASE(LineLinear)
 {
     CheckMesh("line1.msh", 2);
+}
+
+BOOST_AUTO_TEST_CASE(LineQuadratic)
+{
+    CheckMesh("line2.msh", 3);
 }
 
 BOOST_AUTO_TEST_CASE(TetrahedronLinear)

--- a/test/mechanics/mesh/line2.msh
+++ b/test/mechanics/mesh/line2.msh
@@ -1,0 +1,13 @@
+$MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+3
+1 0 0 0
+2 1 0 0
+3 0.4999999999986718 0 0
+$EndNodes
+$Elements
+1
+1 8 2 2 1 1 2 3
+$EndElements


### PR DESCRIPTION
Gmsh node numbering does not always match our numbering, e.g. for
quadratic line elements. This changes in the gmsh import allows
addressing this.