### PR TITLE
Fix bug in Mesh.NodeAtCoordinate

### DIFF
--- a/src/mechanics/mesh/MeshFem.cpp
+++ b/src/mechanics/mesh/MeshFem.cpp
@@ -21,7 +21,7 @@ NodeSimple& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, DofType dofType, d
         {
             NaturalCoords dofNodeCoords = dofInterpolation.GetLocalCoords(iNode);
             Eigen::VectorXd globalNodeCoords = Interpolate(element.CoordinateElement(), dofNodeCoords);
-            if ((globalNodeCoords - coords).isMuchSmallerThan(tol))
+            if ((globalNodeCoords - coords).isMuchSmallerThan(tol, 1))
                 return dofElement.GetNode(iNode);
         }
     }
@@ -39,7 +39,7 @@ NodeSimple& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* = 1.
         for (int iNode = 0; iNode < coordinateElement.Interpolation().GetNumNodes(); ++iNode)
         {
             Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetValues();
-            if ((globalNodeCoords - coords).isMuchSmallerThan(tol))
+            if ((globalNodeCoords - coords).isMuchSmallerThan(tol, 1))
                 return coordinateElement.GetNode(iNode);
         }
     }

--- a/test/mechanics/mesh/MeshFem.cpp
+++ b/test/mechanics/mesh/MeshFem.cpp
@@ -55,7 +55,8 @@ BOOST_AUTO_TEST_CASE(MeshNodeSelectionCoords)
     {
         const auto& n = mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3));
         BoostUnitTest::CheckEigenMatrix(n.GetValues(), Eigen::Vector2d(0, 3));
-        BOOST_CHECK_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 0)), NuTo::Exception);
+        BOOST_CHECK_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3.00001)), NuTo::Exception);
+        BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3.00001), 1e-4));
     }
 
 
@@ -63,7 +64,8 @@ BOOST_AUTO_TEST_CASE(MeshNodeSelectionCoords)
     {
         const auto& n = mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3), d);
         BOOST_CHECK_CLOSE(n.GetValues()[0], 6174, 1.e-10);
-        BOOST_CHECK_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 0), d), NuTo::Exception);
+        BOOST_CHECK_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3.00001), d), NuTo::Exception);
+        BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3.00001), d, 1e-4));
     }
 }
 


### PR DESCRIPTION
Nodes are now found when within prescribed tolerance. (the Eigen isMuchSmallerThan method is used elsewhere correctly).