### PR TITLE
Fix missing find_library in FindSUITESPARSE

### DIFF
--- a/scripts/cmake/FindSUITESPARSE.cmake
+++ b/scripts/cmake/FindSUITESPARSE.cmake
@@ -4,6 +4,7 @@ message(STATUS "Checking for SuiteSparse Solver package ...")
 find_path(SUITESPARSE_INCLUDE_DIR NAMES umfpack.h HINTS /usr/include/suitesparse)
 
 find_library(SUITESPARSE_UMFPACK NAMES umfpack)
+find_library(SUITESPARSE_CHOLMOD NAMES cholmod)
 
 set(SUITESPARSE_LIBRARIES ${SUITESPARSE_UMFPACK} ${SUITESPARSE_CHOLMOD})
 


### PR DESCRIPTION
Accidentally missed adding the `find_library` call for the Cholmod lib. This hopefully fixes that. Not sure why it worked for me, so please let me know if that works for you.