### PR TITLE
Update Dockerfile to fix coverage problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ matrix:
 
 before_install:
     - CI_ENV=`bash <(curl -s https://codecov.io/env)`
-    - travis_retry timeout 120 docker pull nuto/nuto_docker:smaller
-    - docker run $CI_ENV -itd --user nuto --name dock -v $(pwd):/home/nuto/source nuto/nuto_docker:smaller
+    - travis_retry timeout 120 docker pull nuto/nuto_docker:dev
+    - docker run $CI_ENV -itd --user nuto --name dock -v $(pwd):/home/nuto/source nuto/nuto_docker:dev
 
 script:
     # - We log in /home/nuto (set as WORKDIR in Dockerfile). This will be our build directory avoid changing directories.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch
 
 # generic C++ stuff
-RUN apt-get update && apt-get install -y --no-install-recommends g++ clang cmake make libboost-filesystem-dev libboost-mpi-dev libboost-test-dev lcov curl sudo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends g++ clang cmake make libboost-filesystem-dev libboost-mpi-dev libboost-test-dev lcov curl sudo ca-certificates && rm -rf /var/lib/apt/lists/*
 # scientific stuff
 RUN apt-get update && apt-get install -y --no-install-recommends libeigen3-dev libiomp-dev python3-dev python3-numpy libopenblas-dev libmetis-dev libmumps-seq-dev libarpack2-dev gmsh && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Ever since #182, there no longer was any coverage information. That's because the codecov script is pulled via https, but curl was missing this certificates package. Anyway, should work now.