### PR TITLE
Simplify NuTo::Exception

### DIFF
--- a/src/base/Exception.h
+++ b/src/base/Exception.h
@@ -6,16 +6,13 @@
 namespace NuTo
 {
 //! @brief Base class for all exceptions thrown in NuTo.
-class Exception : public std::exception
+class Exception : public std::runtime_error
 {
-protected:
-    std::string mMessage; //!< error message
-
 public:
     //! @brief Constructor.
     //! @param message Error message.
     explicit Exception(const std::string& message)
-        : mMessage(message)
+        : std::runtime_error(message)
     {
     }
 
@@ -23,39 +20,8 @@ public:
     //! @param caller Name of the method that throws.
     //! @param message Error message.
     explicit Exception(const std::string& caller, const std::string& message)
-        : mMessage(std::string("[") + caller + "]\n" + message)
+        : std::runtime_error(std::string("[") + caller + "]\n" + message)
     {
-    }
-
-    //! @brief Destructor.
-    virtual ~Exception()
-    {
-    }
-
-    //! @brief Return error message of the exception.
-    //! @return Error message.
-    virtual std::string ErrorMessage() const
-    {
-        return mMessage;
-    }
-
-    Exception(const Exception&) = default;
-
-    //! @brief Clone the exception.
-    //! @return A copy of the exception.
-    virtual Exception* Clone()
-    {
-        return new Exception(*this);
-    }
-
-    const char* what() const noexcept override
-    {
-        // you can't do `return ErrorMessage().c_str();`
-        // For uncaught exceptions mMessage is out of scope. Thus
-        // the c_str-pointer to its data points nowhere.
-        // A dynamic allocation solves this problem.ü
-        std::string* error = new std::string(ErrorMessage());
-        return error->c_str();
     }
 };
 } // namespace NuTo

--- a/src/geometryConcrete/collision/handler/CollisionHandler.cpp
+++ b/src/geometryConcrete/collision/handler/CollisionHandler.cpp
@@ -136,7 +136,7 @@ double NuTo::CollisionHandler::Simulate(const long rNumEventsMax, const double r
         }
         catch (NuTo::Exception& e)
         {
-            std::cout << e.ErrorMessage() << std::endl;
+            std::cout << e.what() << std::endl;
             std::cout << " fail timestep: " << numEvents << std::endl;
             caughtException = e;
             break;
@@ -177,9 +177,9 @@ double NuTo::CollisionHandler::Simulate(const long rNumEventsMax, const double r
 
 
     // rethrow exceptions for proper test failure
-    if (caughtException.ErrorMessage() != "")
+    if (strcmp(caughtException.what(), ""))
         throw Exception(__PRETTY_FUNCTION__,
-                        "Simulation ended with the exception: \n" + caughtException.ErrorMessage());
+                        "Simulation ended with the exception: \n" + std::string(caughtException.what()));
 
     return finalTimeDifference;
 }

--- a/test/mechanics/timeIntegration/TimeControl.cpp
+++ b/test/mechanics/timeIntegration/TimeControl.cpp
@@ -11,7 +11,8 @@ using namespace NuTo;
 
 bool CheckExceptionMessageCorrect(Exception const& ex, std::string expectedMsg)
 {
-    std::string refinedErrorMessage = ex.ErrorMessage().substr(ex.ErrorMessage().find_first_of("]") + 2);
+    std::string errorMessage = ex.what();
+    std::string refinedErrorMessage = errorMessage.substr(errorMessage.find_first_of("]") + 2);
 
     if (expectedMsg.compare(refinedErrorMessage))
     {


### PR DESCRIPTION
The only useful feature is the (caller, message) syntax. The rest is
just not necessary imho.