### PR TITLE
Separate unit and integration test coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,9 @@ script:
     # - The source code from travis is 'mounted' as /home/nuto/source via the -v option in the docker run command above
     - docker exec dock cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_OPENMP=$OPENMP -DCMAKE_CXX_FLAGS="$COVERAGE $WERROR" ../source
     - docker exec dock make -j2 unit
+    - if [[ "$COVERAGE" == "--coverage" ]]; then docker exec dock bash -c "cd ../source && scripts/upload_coverage.sh unittests"; fi
     - docker exec dock make -j2 integrationtests
     - docker exec dock ctest -R integration --output-on-failure
+    - if [[ "$COVERAGE" == "--coverage" ]]; then docker exec dock bash -c "cd ../source && scripts/upload_coverage.sh integrationtests"; fi
     - docker exec dock make -j2
     - docker exec dock bash ../source/scripts/check_install.sh
-
-after_success:
-    # will simply fail if --coverage is not set.
-    - docker exec dock bash -c "cd ../source && scripts/upload_coverage.sh"

--- a/applications/integrationtests/mechanics/GradientDamage.cpp
+++ b/applications/integrationtests/mechanics/GradientDamage.cpp
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(Integrand)
     //
     //  damage:
     //           _
-    //          / \
+    //          ' '
     //         |   |
     //  _______|   |_______
     //

--- a/scripts/upload_coverage.sh
+++ b/scripts/upload_coverage.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -ev
 # get coverage information
-lcov --capture --directory /home/nuto/build --output-file ../coverage.info # 2> /dev/null
+lcov --capture --directory /home/nuto/build --output-file ../coverage.info
 # filter out system stuff that we don't control
 lcov -r ../coverage.info '/usr/include/*' -o ../coverage.info
 # filter out external libraries
 lcov -r ../coverage.info '/home/nuto/source/external/*' -o ../coverage.info
-# upload to codecov
-bash <(curl -s https://codecov.io/bash) -f ../coverage.info # > /dev/null 2> /dev/null
+# upload to codecov, -F is the flag (unit or integration test)
+bash <(curl -s https://codecov.io/bash) -f ../coverage.info -F $1
+# delete gcda files so that they don't show up in next report
+find /home/nuto/build -name '*.gcda' -delete


### PR DESCRIPTION
Separate reports for unit tests and integration tests. For example, look at [the report of `Cell.h`](https://codecov.io/gh/nutofem/nuto/src/cb6f145f0b869afd43053d3ae0d5bd213379ea1c/src/mechanics/cell/Cell.h), and you can toggle on the upper right which methods got tested by which test suite. Also, the small change in the gradient damage test is to fix a GCC warning. (If you're wondering why that caused a warning, [look here](https://stackoverflow.com/questions/19105350/what-is-the-meaning-of-multi-line-comment-warnings-in-c)). Together with #212, this fixes #64 imho.