### PR TITLE
Fix misc. things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,17 @@ dist: trusty
 matrix:
     include:
         - compiler: clang
-          env: BUILD_TYPE=Release OPENMP=FALSE
+          env: BUILD_TYPE=Release
         - compiler: g++
-          env: BUILD_TYPE=Release OPENMP=FALSE
+          env: BUILD_TYPE=Release
         - compiler: g++
-          env: BUILD_TYPE=Debug OPENMP=FALSE COVERAGE=--coverage
+          env: BUILD_TYPE=Debug COVERAGE=--coverage
         - compiler: clang
-          env: BUILD_TYPE=Release OPENMP=FALSE WERROR=-Werror
+          env: BUILD_TYPE=Release WERROR=-Werror
         - compiler: g++
-          env: BUILD_TYPE=Release OPENMP=FALSE WERROR=-Werror
+          env: BUILD_TYPE=Release WERROR=-Werror
     allow_failures:
-        - env: BUILD_TYPE=Release OPENMP=FALSE WERROR=-Werror
+        - env: BUILD_TYPE=Release WERROR=-Werror
 
 before_install:
     - CI_ENV=`bash <(curl -s https://codecov.io/env)`
@@ -26,11 +26,11 @@ before_install:
 script:
     # - We log in /home/nuto (set as WORKDIR in Dockerfile). This will be our build directory avoid changing directories.
     # - The source code from travis is 'mounted' as /home/nuto/source via the -v option in the docker run command above
-    - docker exec dock cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_OPENMP=$OPENMP -DCMAKE_CXX_FLAGS="$COVERAGE $WERROR" ../source
+    - docker exec dock cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="$COVERAGE $WERROR" ../source
     - docker exec dock make -j2 unit
     - if [[ "$COVERAGE" == "--coverage" ]]; then docker exec dock bash -c "cd ../source && scripts/upload_coverage.sh unittests"; fi
     - docker exec dock make -j2 integrationtests
-    - docker exec dock ctest -R integration --output-on-failure
+    - docker exec dock ctest -R "^integration" --output-on-failure
     - if [[ "$COVERAGE" == "--coverage" ]]; then docker exec dock bash -c "cd ../source && scripts/upload_coverage.sh integrationtests"; fi
     - docker exec dock make -j2
     - docker exec dock bash ../source/scripts/check_install.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,6 @@ project(NuTo)
 
 option(BUILD_SHARED_LIBS "build NuTo libraries as shared libraries" TRUE)
 option(ENABLE_MKL "enables support for mkl blas, lapack, solvers" FALSE)
-option(ENABLE_CUSTOM_EXAMPLES
-    "enable private examples in separate directory (applications/custom)" FALSE)
-option(ENABLE_OPENMP "enables OpenMP" FALSE)
 option(ENABLE_PYTHON "create python wrapper for nuto" FALSE)
 option(ENABLE_MPI "enables message passing interface" FALSE)
 

--- a/scripts/cmake/AddUnitTest.cmake
+++ b/scripts/cmake/AddUnitTest.cmake
@@ -26,7 +26,7 @@ function(add_unit_test ClassName)
     target_link_libraries(${ClassName} Fakeit Eigen3::Eigen)
 
     # generate a ctest name for the test
-    string(REPLACE "." "::" testname ${relpath})
+    string(REPLACE "/" "::" testname ${relpath})
     add_test(unit::${testname}::${ClassName} ${ClassName} --log_level=message)
     set(all_unit_tests "${all_unit_tests};${ClassName}"
         CACHE INTERNAL "The names of all the unit tests")

--- a/scripts/cmake/SetCompilerFlags.cmake
+++ b/scripts/cmake/SetCompilerFlags.cmake
@@ -3,22 +3,6 @@ macro(set_compiler_flags)
     set(CMAKE_CXX_FLAGS
         "${CMAKE_CXX_FLAGS} -Wall -Wextra -msse4 -pedantic -std=c++14 -fPIC")
 
-    # find openmp
-    if(ENABLE_OPENMP)
-        message(STATUS "Checking for OpenMP support ...")
-        find_package(OpenMP)
-        if(OPENMP_FOUND)
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-            set(CMAKE_EXE_LINKER_FLAGS
-                "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_CXX_FLAGS}")
-        endif()
-    else()
-        set(OPENMP_FOUND FALSE)
-        find_package(Threads REQUIRED)
-        #the package finds the THREADS_LIBRARY but does not add the pthread flag
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-    endif()
-
     # before adding warnings that complain about the swig code anyway, we save
     # the flags as they are
     set(PYTHON_CXX_FLAGS "${CMAKE_CXX_FLAGS}")

--- a/scripts/upload_coverage.sh
+++ b/scripts/upload_coverage.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -ev
 # get coverage information
-lcov --capture --directory /home/nuto/build --output-file ../coverage.info
+lcov --capture --directory /home/nuto/build --output-file ../coverage.info > /dev/null
 # filter out system stuff that we don't control
-lcov -r ../coverage.info '/usr/include/*' -o ../coverage.info
+lcov -r ../coverage.info '/usr/include/*' -o ../coverage.info > /dev/null
 # filter out external libraries
 lcov -r ../coverage.info '/home/nuto/source/external/*' -o ../coverage.info
 # upload to codecov, -F is the flag (unit or integration test)


### PR DESCRIPTION
- remove ENABLE_OPENMP
- remove ENABLE_CUSTOM_EXAMPLES
- correct naming of unit tests (some still had a forward slash in them)
- correct running of integration tests (unittests with "integration" in the name where also run, like "IntegrationTypeTensorProduct")
- less output during coverage report creation