### PR TITLE
Pde softening material

### DIFF
--- a/applications/examples/GradientDamageCalibration.cpp
+++ b/applications/examples/GradientDamageCalibration.cpp
@@ -19,13 +19,12 @@
 
 using namespace NuTo;
 
-/* MATERIAL */
-double E = 30000;
-double nu = 0.2;
-double ft = 4;
-double fc = 40;
-double c = 1.00;
-double k0 = ft / E;
+Material::Softening TestMaterial()
+{
+    Material::Softening m = Material::DefaultConcrete();
+    m.fMin = 1.e-10;
+    return m;
+}
 
 //! Solves a 1D tensile test. The load displacement curve is integrated to obtain the global fracture energy. The
 //! localization is triggered by predamaging two elements in the middle of the structure. The fracture energy
@@ -62,6 +61,7 @@ double GlobalFractureEnergy(TGdm& gdm, double L = 50, int nElements = 200, doubl
     CellStorage cellStorage;
     auto cells = cellStorage.AddCells(mesh.ElementsTotal(), integration);
 
+    double k0 = TestMaterial().ft / TestMaterial().E;
     gdm.mKappas.setZero(cells.Size(), nIp);
     gdm.mKappas.row(cells.Size() / 2) = Eigen::VectorXd::Constant(nIp, 3 * k0);
     gdm.mKappas.row(cells.Size() / 2 + 1) = Eigen::VectorXd::Constant(nIp, 3 * k0);
@@ -96,7 +96,7 @@ double GlobalFractureEnergy(TGdm& gdm, double L = 50, int nElements = 200, doubl
 
     Tools::GlobalFractureEnergyIntegrator gfIntegrator(loads, disps);
     double crossSection = 1.;
-    double GfTotal = gfIntegrator.IntegrateSofteningCurve(crossSection, 1.e-3 * ft * crossSection);
+    double GfTotal = gfIntegrator.IntegrateSofteningCurve(crossSection, 1.e-3 * TestMaterial().ft * crossSection);
     // an exception is thrown if the forces in the load-displacement-curve do _not_ drop below this 1.e-5 * ft
 
     double lPreDamage = 2. * nElements / L;
@@ -105,12 +105,12 @@ double GlobalFractureEnergy(TGdm& gdm, double L = 50, int nElements = 200, doubl
 
     // integrate from 0 to 3*k0 with increasing damage
     for (double k = 0; k <= 3 * k0; k += deltaK)
-        preDamageIntegral += (1 - gdm.mDamageLaw.Damage(k)) * E * k * deltaK;
+        preDamageIntegral += (1 - gdm.mDamageLaw.Damage(k)) * TestMaterial().E * k * deltaK;
 
     // subtract the contribution from 0 to 3*k0 with constant damage of omega(3*k0)
     double omega = gdm.mDamageLaw.Damage(3 * k0);
     for (double k = 0; k <= 3 * k0; k += deltaK)
-        preDamageIntegral -= (1 - omega) * E * k * deltaK;
+        preDamageIntegral -= (1 - omega) * TestMaterial().E * k * deltaK;
 
     return GfTotal - lPreDamage * preDamageIntegral;
 }
@@ -127,20 +127,18 @@ double FindRootWithoutDerivative(std::function<double(double)> f, double guess, 
 int main()
 {
     const double GlobalFractureEnergyParameter = 0.1;
+    auto material = TestMaterial();
 
     auto f = [&](double gf) {
         std::cout << "Calculating for local gf = " << gf << " ... ";
+        material.gf = gf;
         std::cout << std::flush;
         DofType d("Displacements", 1);
         ScalarDofType eeq("NonlocalEquivalentStrains");
 
-        Laws::LinearElasticDamage<1> elasticLaw(E, nu);
-        Constitutive::DamageLawExponential dmg(k0, ft / gf, 0.999999);
-        Constitutive::ModifiedMisesStrainNorm<1> strainNorm(nu, fc / ft);
-
         NonlocalInteraction::Decreasing interaction(0.1, 5);
-        using Gdm = Integrands::GradientDamage<1, Constitutive::DamageLawExponential, NonlocalInteraction::Decreasing>;
-        Gdm gdm(d, eeq, c, elasticLaw, dmg, strainNorm, interaction);
+        using Gdm = Integrands::GradientDamage<1, NonlocalInteraction::Decreasing>;
+        Gdm gdm(d, eeq, material, Laws::eDamageApplication::FULL, interaction);
         double Gf = GlobalFractureEnergy(gdm);
         std::cout << "gives global Gf = " << Gf << ".\n";
         return Gf - GlobalFractureEnergyParameter;

--- a/applications/integrationtests/mechanics/CSDAInterface.cpp
+++ b/applications/integrationtests/mechanics/CSDAInterface.cpp
@@ -59,15 +59,12 @@ void CheckFractureEnergy2D(int angleDegree, double interfaceThickness)
     NuTo::DofType d("Displ", 2);
     element.AddDofElement(d, {{nd0, nd1, nd2, nd3}, interpolation});
 
-    NuTo::Laws::LinearElasticDamage<2> elasticDamage(20000., 0.);
-    double k0 = 4. / 20000;
+    auto material = NuTo::Material::DefaultConcrete();
     double Gf = 0.1;
-    double gf = 4. * interfaceThickness / Gf;
-    NuTo::Constitutive::DamageLawExponential damageLaw(k0, gf, 1.);
-    using Law = NuTo::Laws::LocalIsotropicDamage<2, NuTo::Constitutive::DamageLawExponential,
-                                                 NuTo::Laws::EvolutionImplicit<2>>;
-    Law law(elasticDamage, damageLaw, {{0., 10}});
-
+    material.nu = 0.;
+    material.gf = Gf / interfaceThickness;
+    material.fMin = 0;
+    NuTo::Laws::LocalIsotropicDamage<2> law(material);
     NuTo::Integrands::MomentumBalance<2> momentum(d, law);
 
     NuTo::DofNumbering::Build({nd0, nd1, nd2, nd3}, d, {}); // numbering without constraints

--- a/applications/integrationtests/mechanics/StructuralGradientDamage.cpp
+++ b/applications/integrationtests/mechanics/StructuralGradientDamage.cpp
@@ -7,7 +7,6 @@
 
 #include "nuto/mechanics/integrands/GradientDamage.h"
 #include "nuto/mechanics/integrands/NeumannBc.h"
-#include "nuto/mechanics/constitutive/damageLaws/DamageLawExponential.h"
 #include "nuto/mechanics/mesh/UnitMeshFem.h"
 #include "nuto/mechanics/mesh/MeshGmsh.h"
 #include "nuto/mechanics/mesh/MeshFemDofConvert.h"
@@ -29,22 +28,14 @@ BOOST_AUTO_TEST_CASE(Integrand)
     DofType d("Displacements", 1);
     ScalarDofType eeq("NonlocalEquivalentStrains");
 
-    /* MATERIAL */
-    double E = 30000;
-    double nu = 0.2;
-    double ft = 4;
-    double fc = 40;
-    double gf = 0.021 * 10; // we have to adjust the material parameters due to nonlocal decreasing interaction
     double L = 40;
-    double c = 0.25;
+    auto material = Material::DefaultConcrete();
+    material.gf = 0.021 * 10;
+    material.c = 0.25;
+    double k0 = material.ft / material.E;
 
-    double k0 = ft / E;
-    Laws::LinearElasticDamage<1> elasticLaw(E, nu);
-    Constitutive::DamageLawExponential dmg(k0, ft / gf, 1.);
-    Constitutive::ModifiedMisesStrainNorm<1> strainNorm(nu, fc / ft);
-
-    using Gdm = Integrands::GradientDamage<1, Constitutive::DamageLawExponential, NonlocalInteraction::Decreasing>;
-    Gdm gdm(d, eeq, c, elasticLaw, dmg, strainNorm);
+    using Gdm = Integrands::GradientDamage<1, NonlocalInteraction::Decreasing>;
+    Gdm gdm(d, eeq, material);
 
     /* mesh, interpolations, constraints */
     MeshFem mesh = UnitMeshFem::Transform(UnitMeshFem::CreateLines(80),
@@ -161,26 +152,17 @@ BOOST_AUTO_TEST_CASE(Integrand2D)
     binaryPath.remove_filename();
     std::string meshFile = binaryPath.string() + "/meshes/Holes.msh";
 
-    double E = 30000;
-    double nu = 0.2;
-    Laws::LinearElasticDamage<2> unilateralLaw(E, nu, Laws::UNILATERAL);
-
-    double ft = 4;
-    double gf = 0.021 * 10;
-    Constitutive::DamageLawExponential dmg(ft / E, ft / gf, 0.99);
-
-    double fc = 40;
-    Constitutive::ModifiedMisesStrainNorm<2> strainNorm(nu, fc / ft);
-
+    auto material = Material::DefaultConcrete();
+    material.gf = 0.21;
+    material.c = 2;
 
     DofType d("Displacements", 2);
     ScalarDofType eeq("NonlocalEquivalentStrains");
 
-    double c = 2.0;
-    using Gdm = Integrands::GradientDamage<2, Constitutive::DamageLawExponential>;
+    using Gdm = Integrands::GradientDamage<2>;
     using Neumann = Integrands::NeumannBc<2>;
 
-    Gdm gdm(d, eeq, c, unilateralLaw, dmg, strainNorm);
+    Gdm gdm(d, eeq, material);
     Neumann neumann(d, Eigen::Vector2d(.42, .12));
 
     MeshGmsh gmsh(meshFile);

--- a/nuto/mechanics/constitutive/LinearElasticDamage.h
+++ b/nuto/mechanics/constitutive/LinearElasticDamage.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "nuto/base/Exception.h"
-#include "nuto/mechanics/constitutive/ConstitutivePlaneStateEnum.h"
-#include "nuto/mechanics/constitutive/EngineeringTangent.h"
-#include "nuto/mechanics/constitutive/EngineeringStrain.h"
-#include "nuto/mechanics/constitutive/EngineeringStress.h"
+#include "ConstitutivePlaneStateEnum.h"
+#include "EngineeringTangent.h"
+#include "EngineeringStrain.h"
+#include "EngineeringStress.h"
+#include "damageLaws/SofteningMaterial.h"
 
 namespace NuTo
 {
@@ -44,6 +45,13 @@ public:
             m2G = E;
         }
     }
+
+    LinearElasticDamage(Material::Softening m, eDamageApplication damageApplication = FULL,
+                        ePlaneState planeState = ePlaneState::PLANE_STRAIN)
+        : LinearElasticDamage::LinearElasticDamage(m.E, m.nu, damageApplication, planeState)
+    {
+    }
+
 
     EngineeringStress<TDim> Stress(EngineeringStrain<TDim> strain, double omega) const
     {

--- a/nuto/mechanics/constitutive/ModifiedMisesStrainNorm.h
+++ b/nuto/mechanics/constitutive/ModifiedMisesStrainNorm.h
@@ -1,8 +1,9 @@
 #pragma once
 #include "nuto/base/Exception.h"
-#include "nuto/mechanics/constitutive/ConstitutivePlaneStateEnum.h"
-#include "nuto/mechanics/constitutive/EngineeringStrain.h"
-#include "nuto/mechanics/constitutive/EngineeringStrainInvariants.h"
+#include "ConstitutivePlaneStateEnum.h"
+#include "EngineeringStrain.h"
+#include "EngineeringStrainInvariants.h"
+#include "damageLaws/SofteningMaterial.h"
 
 namespace NuTo
 {
@@ -35,6 +36,12 @@ public:
     //! @param k ratio of compressive strength to tensile strength, ~10 for concrete
     //! @param planeState PLANE_STRAIN or PLANE_STRESS
     ModifiedMisesStrainNorm(double nu, double k, ePlaneState planeState = ePlaneState::PLANE_STRAIN);
+
+    //! Constructor.
+    //! @param m softening material parameters
+    //! @param planeState PLANE_STRAIN or PLANE_STRESS
+    ModifiedMisesStrainNorm(Material::Softening m, ePlaneState planeState = ePlaneState::PLANE_STRAIN);
+
 
     //! @param strain strain to evaluate
     //! @return the value of the modified Mises strain norm
@@ -70,6 +77,11 @@ inline ModifiedMisesStrainNorm<TDim>::ModifiedMisesStrainNorm(double nu, double 
 {
 }
 
+template <int TDim>
+inline ModifiedMisesStrainNorm<TDim>::ModifiedMisesStrainNorm(Material::Softening m, ePlaneState planeState)
+    : ModifiedMisesStrainNorm<TDim>::ModifiedMisesStrainNorm(m.nu, m.fc / m.ft, planeState)
+{
+}
 
 template <>
 inline EngineeringStrain<3> ModifiedMisesStrainNorm<1>::Strain3D(const EngineeringStrain<1>& strain, double nu,

--- a/nuto/mechanics/constitutive/damageLaws/DamageLawExponential.h
+++ b/nuto/mechanics/constitutive/damageLaws/DamageLawExponential.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <cmath>
-#include "nuto/mechanics/constitutive/damageLaws/DamageLaw.h"
+#include "DamageLaw.h"
+#include "SofteningMaterial.h"
 
 namespace NuTo
 {
@@ -26,6 +27,12 @@ public:
         : mKappa0(kappa0)
         , mBeta(beta)
         , mAlpha(alpha)
+    {
+    }
+    DamageLawExponential(Material::Softening m)
+        : mKappa0(m.ft / m.E)
+        , mBeta(m.ft / m.gf)
+        , mAlpha(1 - m.fMin / m.ft)
     {
     }
 

--- a/nuto/mechanics/constitutive/damageLaws/DamageLawLinear.h
+++ b/nuto/mechanics/constitutive/damageLaws/DamageLawLinear.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <algorithm> // std::min
-#include "nuto/mechanics/constitutive/damageLaws/DamageLaw.h"
+#include "DamageLaw.h"
+#include "SofteningMaterial.h"
 
 namespace NuTo
 {
@@ -25,6 +26,13 @@ public:
         : mKappa0(kappa0)
         , mKappaC(kappaC)
         , mOmegaMax(omegaMax)
+    {
+    }
+
+    DamageLawLinear(Material::Softening m)
+        : mKappa0(m.ft / m.E)
+        , mKappaC(mKappa0 + 2. * m.gf / m.ft)
+        , mOmegaMax(1. - m.fMin / m.ft) // this is not totally right...
     {
     }
 

--- a/nuto/mechanics/constitutive/damageLaws/DamageLawNoSoftening.h
+++ b/nuto/mechanics/constitutive/damageLaws/DamageLawNoSoftening.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <memory>
-#include "nuto/mechanics/constitutive/damageLaws/DamageLaw.h"
+#include "DamageLaw.h"
+#include "SofteningMaterial.h"
 
 namespace NuTo
 {
@@ -23,6 +23,10 @@ class DamageLawNoSoftening : public DamageLaw
 public:
     DamageLawNoSoftening(double kappa0)
         : mKappa0(kappa0)
+    {
+    }
+    DamageLawNoSoftening(Material::Softening m)
+        : mKappa0(m.ft / m.E)
     {
     }
 

--- a/nuto/mechanics/constitutive/damageLaws/SofteningMaterial.h
+++ b/nuto/mechanics/constitutive/damageLaws/SofteningMaterial.h
@@ -1,0 +1,50 @@
+#pragma once
+
+namespace NuTo
+{
+namespace Material
+{
+//! Common material parameters for softening materials
+//! @remark For simplicity, we use the common short symbols here. For readability, we deviate from the naming convention
+//! (m... ) for members.
+struct Softening
+{
+    //! Young's modulus [pressure]
+    double E;
+
+    //! Poisson's ratio [-]
+    double nu;
+
+    //! tensile strength [pressure]
+    double ft;
+
+    //! compressive strength [pressure]
+    double fc;
+
+    //! fracture energy parameter [energy per area / pressure times length ]
+    double gf;
+
+    //! nonlocal radius c = l^2 [length]
+    double c;
+
+    //! residual strength [pressure]
+    double fMin;
+};
+
+//! Sets the softening material parameters to approximate normal strength concrete
+//! @remark units: length = mm, pressure = MPa
+inline Softening DefaultConcrete()
+{
+    Softening m;
+    m.E = 30000;
+    m.nu = 0.2;
+    m.ft = 4;
+    m.fc = 40;
+    m.gf = 0.1;
+    m.c = 1;
+    m.fMin = 0.01 * m.ft;
+    return m;
+}
+
+} /* NuTo */
+} /* Material */

--- a/test/mechanics/constitutive/damageLaws/DamageLawExponential.cpp
+++ b/test/mechanics/constitutive/damageLaws/DamageLawExponential.cpp
@@ -21,3 +21,11 @@ BOOST_AUTO_TEST_CASE(ExponentialResLoad)
         BOOST_CHECK_CLOSE(pseudoStress, sigma_infty, 1.e-3);
     }
 }
+
+BOOST_AUTO_TEST_CASE(ExponentialMaterial)
+{
+    NuTo::Material::Softening m = NuTo::Material::DefaultConcrete();
+    m.fMin = 0;
+    NuTo::Constitutive::DamageLawExponential law(m);
+    DamageLawHelper::CheckFractureEnergy(law, m);
+}

--- a/test/mechanics/constitutive/damageLaws/DamageLawHelper.h
+++ b/test/mechanics/constitutive/damageLaws/DamageLawHelper.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "BoostUnitTest.h"
 #include "nuto/mechanics/constitutive/damageLaws/DamageLaw.h"
+#include "nuto/mechanics/constitutive/damageLaws/SofteningMaterial.h"
 
 namespace DamageLawHelper
 {
@@ -22,5 +23,19 @@ void CheckDerivatives(const NuTo::Constitutive::DamageLaw& law, double kappa0, d
         const double derivativeCDF = (law.Damage(kappa + .5 * delta) - law.Damage(kappa - .5 * delta)) / delta;
         BOOST_CHECK_SMALL(derivative - derivativeCDF, 1.e-4);
     }
+}
+
+void CheckFractureEnergy(const NuTo::Constitutive::DamageLaw& law, NuTo::Material::Softening m)
+{
+    double k0 = m.ft / m.E;
+    double dk = k0 / 10.;
+    double gf = 0;
+    for (double k = k0; k < 10000 * k0; k += dk)
+    {
+        double sigma_a = (1. - law.Damage(k)) * m.E * k;
+        double sigma_b = (1. - law.Damage(k + dk)) * m.E * (k + dk);
+        gf += 0.5 * dk * (sigma_a + sigma_b);
+    }
+    BOOST_CHECK_CLOSE(gf, m.gf, 1.e-5);
 }
 } /* DamageLawHelper */

--- a/test/mechanics/constitutive/damageLaws/DamageLawLinear.cpp
+++ b/test/mechanics/constitutive/damageLaws/DamageLawLinear.cpp
@@ -26,3 +26,11 @@ BOOST_AUTO_TEST_CASE(LinearDamageMax)
             BOOST_CHECK_LE(law.Damage(kappa), damageMax);
     }
 }
+
+BOOST_AUTO_TEST_CASE(LinearDamageMaterial)
+{
+    NuTo::Material::Softening m = NuTo::Material::DefaultConcrete();
+    m.fMin = 0;
+    NuTo::Constitutive::DamageLawLinear law(m);
+    DamageLawHelper::CheckFractureEnergy(law, m);
+}


### PR DESCRIPTION
Basically solves #232.

- Introduce a `Material` namespace, in this case containing `Material::Softening` with all necessary parameters. A `Material::DefaultConcrete()` is provided and used in the tests.
- Main code addition is adding ctors that take this material instead of the single parameters
- Allows defaulting most of the template parameters of `LocalIsotropicDamage` and `GradientDamage` and simplifies the ctors
- At least one damage law parameter is related to the fracture energy. This obviously differs for linear softening and exponential softening. Test are added to ensure correctness here.
