### PR TITLE
Pde assembler

### DIFF
--- a/nuto/mechanics/cell/Assembler.cpp
+++ b/nuto/mechanics/cell/Assembler.cpp
@@ -1,0 +1,164 @@
+#include "Assembler.h"
+#include "nuto/base/Exception.h"
+
+std::vector<NuTo::DofType> AvailableDofTypes(const NuTo::DofVector<int>& n, std::vector<NuTo::DofType> dofTypes)
+{
+    if (dofTypes.empty())
+        return n.DofTypes();
+
+    std::vector<NuTo::DofType> intersection;
+    for (const auto& dofTypeRow : n.DofTypes())
+        for (const auto& dofTypeCol : dofTypes)
+            if (dofTypeRow.Id() == dofTypeCol.Id())
+            {
+                intersection.push_back(dofTypeRow);
+                continue;
+            }
+    return intersection;
+}
+
+NuTo::VectorAssembler::VectorAssembler(DofContainer<int> sizes)
+{
+    Resize(sizes);
+}
+
+void NuTo::VectorAssembler::Resize(DofContainer<int> sizes)
+{
+    for (auto dofSize : sizes)
+        mVector[dofSize.first].setZero(dofSize.second);
+}
+
+void NuTo::VectorAssembler::Add(const DofVector<double>& v, const DofVector<int>& numbering,
+                                std::vector<DofType> dofTypes)
+{
+    for (const auto& dofType : AvailableDofTypes(numbering, dofTypes))
+    {
+        for (unsigned localDofNumber = 0; localDofNumber < numbering[dofType].size(); ++localDofNumber)
+        {
+            const int globalDofNumber = numbering[dofType][localDofNumber];
+            mVector[dofType][globalDofNumber] += v[dofType][localDofNumber];
+        }
+    }
+}
+
+void NuTo::VectorAssembler::SetZero()
+{
+    for (const auto& dofType : mVector.DofTypes())
+        mVector[dofType].setZero();
+}
+
+const NuTo::DofVector<double>& NuTo::VectorAssembler::Get() const
+{
+    return mVector;
+}
+
+NuTo::MatrixAssembler::MatrixAssembler(DofContainer<int> sizes)
+{
+    Resize(sizes);
+}
+
+void NuTo::MatrixAssembler::Resize(DofContainer<int> sizes)
+{
+    if (mFinished)
+        throw Exception(__PRETTY_FUNCTION__,
+                        "You are not allowed to resize the assembler matrix once ::Finished() is called.");
+
+    for (auto dofTypeRow : sizes)
+        for (auto dofTypeCol : sizes)
+            mMatrix(dofTypeRow.first, dofTypeCol.first).resize(dofTypeRow.second, dofTypeCol.second);
+}
+
+void NuTo::MatrixAssembler::Add(const DofMatrix<double>& m, const DofVector<int>& numbering,
+                                std::vector<DofType> dofTypes)
+{
+    if (mFinished)
+    {
+        // We can now assemble in the exising nonzeros of this->mMatrix
+        MatrixAssembler::Add(mMatrix, m, numbering, dofTypes);
+        return;
+    }
+
+    auto availableDofTypes = AvailableDofTypes(numbering, dofTypes);
+    for (const auto& dofTypeRow : availableDofTypes)
+    {
+        for (const auto& dofTypeCol : availableDofTypes)
+        {
+            auto& tripletListDof = mTriplets(dofTypeRow, dofTypeCol);
+            const auto& matrixDof = m(dofTypeRow, dofTypeCol);
+            const auto& numberingRow = numbering[dofTypeRow];
+            const auto& numberingCol = numbering[dofTypeCol];
+
+            for (unsigned localRow = 0; localRow < numberingRow.size(); ++localRow)
+            {
+                for (unsigned localCol = 0; localCol < numberingCol.size(); ++localCol)
+                {
+                    const int globalRow = numberingRow[localRow];
+                    const int globalCol = numberingCol[localCol];
+                    const double value = matrixDof(localRow, localCol);
+                    tripletListDof.push_back({globalRow, globalCol, value});
+                }
+            }
+        }
+    }
+}
+
+void NuTo::MatrixAssembler::Add(DofMatrixSparse<double>& rSparseMatrix, const DofMatrix<double>& m,
+                                const DofVector<int>& numbering, std::vector<DofType> dofTypes)
+{
+    auto availableDofTypes = AvailableDofTypes(numbering, dofTypes);
+    for (const auto& dofTypeRow : availableDofTypes)
+    {
+        for (const auto& dofTypeCol : availableDofTypes)
+        {
+            auto& sparseMatrixDof = rSparseMatrix(dofTypeRow, dofTypeCol);
+            const auto& matrixDof = m(dofTypeRow, dofTypeCol);
+            const auto& numberingRow = numbering[dofTypeRow];
+            const auto& numberingCol = numbering[dofTypeCol];
+
+            for (unsigned localRow = 0; localRow < numberingRow.size(); ++localRow)
+            {
+                for (unsigned localCol = 0; localCol < numberingCol.size(); ++localCol)
+                {
+                    const int globalRow = numberingRow[localRow];
+                    const int globalCol = numberingCol[localCol];
+                    const double value = matrixDof(localRow, localCol);
+                    sparseMatrixDof.coeffRef(globalRow, globalCol) += value;
+                }
+            }
+        }
+    }
+}
+
+void NuTo::MatrixAssembler::SetZero()
+{
+    for (auto dofTypeRow : mMatrix.DofTypes())
+        for (auto dofTypeCol : mMatrix.DofTypes())
+            mMatrix(dofTypeRow, dofTypeCol).setZero();
+}
+
+void NuTo::MatrixAssembler::Finish()
+{
+    if (mFinished)
+        return;
+
+    for (auto dofTypeRow : mMatrix.DofTypes())
+    {
+        for (auto dofTypeCol : mMatrix.DofTypes())
+        {
+            auto& tripletListDof = mTriplets(dofTypeRow, dofTypeCol);
+            auto& matrix = mMatrix(dofTypeRow, dofTypeCol);
+            matrix.setFromTriplets(tripletListDof.begin(), tripletListDof.end());
+            matrix.makeCompressed();
+            tripletListDof.clear();
+            tripletListDof.shrink_to_fit();
+        }
+    }
+    mFinished = true;
+}
+
+const NuTo::DofMatrixSparse<double>& NuTo::MatrixAssembler::Get() const
+{
+    if (not mFinished)
+        throw Exception(__PRETTY_FUNCTION__, "You have to call ::Finish() first to complete the assembly!");
+    return mMatrix;
+}

--- a/nuto/mechanics/cell/Assembler.cpp
+++ b/nuto/mechanics/cell/Assembler.cpp
@@ -17,6 +17,74 @@ std::vector<NuTo::DofType> AvailableDofTypes(const NuTo::DofVector<int>& n, std:
     return intersection;
 }
 
+void NuTo::Assembler::Add(DofVector<double>& rVector, const DofVector<double>& v, const DofVector<int>& numbering,
+                          std::vector<DofType> dofTypes)
+{
+    for (const auto& dofType : AvailableDofTypes(numbering, dofTypes))
+    {
+        for (unsigned localDofNumber = 0; localDofNumber < numbering[dofType].size(); ++localDofNumber)
+        {
+            const int globalDofNumber = numbering[dofType][localDofNumber];
+            rVector[dofType][globalDofNumber] += v[dofType][localDofNumber];
+        }
+    }
+}
+
+void NuTo::Assembler::Add(DofMatrixContainer<std::vector<Eigen::Triplet<double>>>& rTriplets,
+                          const DofMatrix<double>& m, const DofVector<int>& numbering, std::vector<DofType> dofTypes)
+{
+    auto availableDofTypes = AvailableDofTypes(numbering, dofTypes);
+    for (const auto& dofTypeRow : availableDofTypes)
+    {
+        for (const auto& dofTypeCol : availableDofTypes)
+        {
+            auto& tripletListDof = rTriplets(dofTypeRow, dofTypeCol);
+            const auto& matrixDof = m(dofTypeRow, dofTypeCol);
+            const auto& numberingRow = numbering[dofTypeRow];
+            const auto& numberingCol = numbering[dofTypeCol];
+
+            for (unsigned localRow = 0; localRow < numberingRow.size(); ++localRow)
+            {
+                for (unsigned localCol = 0; localCol < numberingCol.size(); ++localCol)
+                {
+                    const int globalRow = numberingRow[localRow];
+                    const int globalCol = numberingCol[localCol];
+                    const double value = matrixDof(localRow, localCol);
+                    tripletListDof.push_back({globalRow, globalCol, value});
+                }
+            }
+        }
+    }
+}
+
+void NuTo::Assembler::Add(DofMatrixSparse<double>& rSparseMatrix, const DofMatrix<double>& m,
+                          const DofVector<int>& numbering, std::vector<DofType> dofTypes)
+{
+    auto availableDofTypes = AvailableDofTypes(numbering, dofTypes);
+    for (const auto& dofTypeRow : availableDofTypes)
+    {
+        for (const auto& dofTypeCol : availableDofTypes)
+        {
+            auto& sparseMatrixDof = rSparseMatrix(dofTypeRow, dofTypeCol);
+            const auto& matrixDof = m(dofTypeRow, dofTypeCol);
+            const auto& numberingRow = numbering[dofTypeRow];
+            const auto& numberingCol = numbering[dofTypeCol];
+
+            for (unsigned localRow = 0; localRow < numberingRow.size(); ++localRow)
+            {
+                for (unsigned localCol = 0; localCol < numberingCol.size(); ++localCol)
+                {
+                    const int globalRow = numberingRow[localRow];
+                    const int globalCol = numberingCol[localCol];
+                    const double value = matrixDof(localRow, localCol);
+                    sparseMatrixDof.coeffRef(globalRow, globalCol) += value;
+                }
+            }
+        }
+    }
+}
+
+
 NuTo::VectorAssembler::VectorAssembler(DofContainer<int> sizes)
 {
     Resize(sizes);
@@ -31,14 +99,7 @@ void NuTo::VectorAssembler::Resize(DofContainer<int> sizes)
 void NuTo::VectorAssembler::Add(const DofVector<double>& v, const DofVector<int>& numbering,
                                 std::vector<DofType> dofTypes)
 {
-    for (const auto& dofType : AvailableDofTypes(numbering, dofTypes))
-    {
-        for (unsigned localDofNumber = 0; localDofNumber < numbering[dofType].size(); ++localDofNumber)
-        {
-            const int globalDofNumber = numbering[dofType][localDofNumber];
-            mVector[dofType][globalDofNumber] += v[dofType][localDofNumber];
-        }
-    }
+    Assembler::Add(mVector, v, numbering, dofTypes);
 }
 
 void NuTo::VectorAssembler::SetZero()
@@ -68,66 +129,17 @@ void NuTo::MatrixAssembler::Resize(DofContainer<int> sizes)
             mMatrix(dofTypeRow.first, dofTypeCol.first).resize(dofTypeRow.second, dofTypeCol.second);
 }
 
+
 void NuTo::MatrixAssembler::Add(const DofMatrix<double>& m, const DofVector<int>& numbering,
                                 std::vector<DofType> dofTypes)
 {
     if (mFinished)
-    {
         // We can now assemble in the exising nonzeros of this->mMatrix
-        MatrixAssembler::Add(mMatrix, m, numbering, dofTypes);
-        return;
-    }
-
-    auto availableDofTypes = AvailableDofTypes(numbering, dofTypes);
-    for (const auto& dofTypeRow : availableDofTypes)
-    {
-        for (const auto& dofTypeCol : availableDofTypes)
-        {
-            auto& tripletListDof = mTriplets(dofTypeRow, dofTypeCol);
-            const auto& matrixDof = m(dofTypeRow, dofTypeCol);
-            const auto& numberingRow = numbering[dofTypeRow];
-            const auto& numberingCol = numbering[dofTypeCol];
-
-            for (unsigned localRow = 0; localRow < numberingRow.size(); ++localRow)
-            {
-                for (unsigned localCol = 0; localCol < numberingCol.size(); ++localCol)
-                {
-                    const int globalRow = numberingRow[localRow];
-                    const int globalCol = numberingCol[localCol];
-                    const double value = matrixDof(localRow, localCol);
-                    tripletListDof.push_back({globalRow, globalCol, value});
-                }
-            }
-        }
-    }
+        Assembler::Add(mMatrix, m, numbering, dofTypes);
+    else
+        Assembler::Add(mTriplets, m, numbering, dofTypes);
 }
 
-void NuTo::MatrixAssembler::Add(DofMatrixSparse<double>& rSparseMatrix, const DofMatrix<double>& m,
-                                const DofVector<int>& numbering, std::vector<DofType> dofTypes)
-{
-    auto availableDofTypes = AvailableDofTypes(numbering, dofTypes);
-    for (const auto& dofTypeRow : availableDofTypes)
-    {
-        for (const auto& dofTypeCol : availableDofTypes)
-        {
-            auto& sparseMatrixDof = rSparseMatrix(dofTypeRow, dofTypeCol);
-            const auto& matrixDof = m(dofTypeRow, dofTypeCol);
-            const auto& numberingRow = numbering[dofTypeRow];
-            const auto& numberingCol = numbering[dofTypeCol];
-
-            for (unsigned localRow = 0; localRow < numberingRow.size(); ++localRow)
-            {
-                for (unsigned localCol = 0; localCol < numberingCol.size(); ++localCol)
-                {
-                    const int globalRow = numberingRow[localRow];
-                    const int globalCol = numberingCol[localCol];
-                    const double value = matrixDof(localRow, localCol);
-                    sparseMatrixDof.coeffRef(globalRow, globalCol) += value;
-                }
-            }
-        }
-    }
-}
 
 void NuTo::MatrixAssembler::SetZero()
 {

--- a/nuto/mechanics/cell/Assembler.h
+++ b/nuto/mechanics/cell/Assembler.h
@@ -7,6 +7,34 @@
 namespace NuTo
 {
 
+namespace Assembler
+{
+//! adds an arbitrary contribution `v` to the internal DofVector
+//! @param v contribution, e.g. a local element/cell vector
+//! @param numbering mapping from local (0...numbering.size()) to global (0...sizes)
+//! @param dofTypes specific dof types to assemble - an empty value will assemble all available dof types from the
+//! numbering
+void Add(DofVector<double>& rResult, const DofVector<double>& v, const DofVector<int>& numbering,
+         std::vector<DofType> dofTypes = {});
+
+//! adds an arbitrary contribution `m` to `rSparseMatrix`
+//! @param m contribution, e.g. a local element/cell matrix
+//! @param numbering mapping from local (0...numbering.size()) to global (0...sizes)
+//! @param dofTypes specific dof types to assemble - an empty value will assemble all available dof types from the
+//! numbering
+void Add(DofMatrixSparse<double>& rSparseMatrix, const DofMatrix<double>& m, const DofVector<int>& numbering,
+         std::vector<DofType> dofTypes = {});
+
+
+//! adds an arbitrary contribution `m` to `rSparseMatrix`
+//! @param m contribution, e.g. a local element/cell matrix
+//! @param numbering mapping from local (0...numbering.size()) to global (0...sizes)
+//! @param dofTypes specific dof types to assemble - an empty value will assemble all available dof types from the
+//! numbering
+void Add(DofMatrixContainer<std::vector<Eigen::Triplet<double>>>& rTriplets, const DofMatrix<double>& m,
+         const DofVector<int>& numbering, std::vector<DofType> dofTypes = {});
+}
+
 //! Assembles an internal NuTo::DofVector<double> from arbitrary contributions and provides access to it
 class VectorAssembler
 {
@@ -58,14 +86,6 @@ public:
     //! @param dofTypes specific dof types to assemble - an empty value will assemble all available dof types from the
     //! numbering
     void Add(const DofMatrix<double>& m, const DofVector<int>& numbering, std::vector<DofType> dofTypes = {});
-
-    //! adds an arbitrary contribution `m` to `rSparseMatrix`
-    //! @param m contribution, e.g. a local element/cell matrix
-    //! @param numbering mapping from local (0...numbering.size()) to global (0...sizes)
-    //! @param dofTypes specific dof types to assemble - an empty value will assemble all available dof types from the
-    //! numbering
-    static void Add(DofMatrixSparse<double>& rSparseMatrix, const DofMatrix<double>& m, const DofVector<int>& numbering,
-                    std::vector<DofType> dofTypes = {});
 
     //! sets the entries of the internal DofMatrixSparse to zero but keeps the nonzeros
     void SetZero();

--- a/nuto/mechanics/cell/Assembler.h
+++ b/nuto/mechanics/cell/Assembler.h
@@ -1,0 +1,76 @@
+#pragma once
+#include "nuto/mechanics/dofs/DofInfo.h"
+#include "nuto/mechanics/dofs/DofContainer.h"
+#include "nuto/mechanics/dofs/DofVector.h"
+#include "nuto/mechanics/dofs/DofMatrix.h"
+#include "nuto/mechanics/dofs/DofMatrixSparse.h"
+
+namespace NuTo
+{
+
+std::vector<DofType> AvailableDofTypes(const DofVector<int> n, std::vector<DofType> dofTypes)
+{
+    if (dofTypes.empty())
+        return n.DofTypes();
+
+    std::vector<DofType> intersection;
+    for (const auto& d1 : n.DofTypes())
+        for (const auto& d2 : dofTypes)
+            if (d1.Id() == d2.Id())
+            {
+                intersection.push_back(d1);
+                continue;
+            }
+    return intersection;
+}
+
+class VectorAssembler
+{
+public:
+    VectorAssembler(DofContainer<int> sizes = {})
+    {
+        Resize(sizes);
+    }
+
+    void Resize(DofContainer<int> sizes)
+    {
+        for (auto dofSize : sizes)
+            mVector[dofSize.first].setZero(dofSize.second);
+    }
+
+    void Add(const DofVector<double>& v, const DofVector<int>& numbering, std::vector<DofType> dofTypes = {})
+    {
+        for (const auto& dofType : AvailableDofTypes(numbering, dofTypes))
+        {
+            for (unsigned localDofNumber = 0; localDofNumber < numbering[dofType].size(); ++localDofNumber)
+            {
+                const int globalDofNumber = numbering[dofType][localDofNumber];
+                mVector[dofType][globalDofNumber] += v[dofType][localDofNumber];
+            }
+        }
+    }
+
+    void Reset()
+    {
+        for (const auto& dofType : mVector.DofTypes())
+            mVector[dofType].setZero();
+    }
+
+    const DofVector<double>& Get() const
+    {
+        return mVector;
+    }
+
+private:
+    DofVector<double> mVector;
+};
+
+class MatrixAssembler
+{
+public:
+private:
+    DofVector<double> mVector;
+};
+
+
+} /* NuTo */

--- a/nuto/mechanics/cell/Assembler.h
+++ b/nuto/mechanics/cell/Assembler.h
@@ -65,6 +65,7 @@ private:
     DofVector<double> mVector;
 };
 
+
 class MatrixAssembler
 {
 public:
@@ -100,6 +101,33 @@ public:
                         const int globalCol = numberingCol[localCol];
                         const double value = matrixDof(localRow, localCol);
                         tripletListDof.push_back({globalRow, globalCol, value});
+                    }
+                }
+            }
+        }
+    }
+
+    static void Add(DofMatrixSparse<double>& rSparseMatrix, const DofMatrix<double>& m, const DofVector<int>& numbering,
+                    std::vector<DofType> dofTypes = {})
+    {
+        auto availableDofTypes = AvailableDofTypes(numbering, dofTypes);
+        for (const auto& dofTypeRow : availableDofTypes)
+        {
+            for (const auto& dofTypeCol : availableDofTypes)
+            {
+                auto& sparseMatrixDof = rSparseMatrix(dofTypeRow, dofTypeCol);
+                const auto& matrixDof = m(dofTypeRow, dofTypeCol);
+                const auto& numberingRow = numbering[dofTypeRow];
+                const auto& numberingCol = numbering[dofTypeCol];
+
+                for (unsigned localRow = 0; localRow < numberingRow.size(); ++localRow)
+                {
+                    for (unsigned localCol = 0; localCol < numberingCol.size(); ++localCol)
+                    {
+                        const int globalRow = numberingRow[localRow];
+                        const int globalCol = numberingCol[localCol];
+                        const double value = matrixDof(localRow, localCol);
+                        sparseMatrixDof.coeffRef(globalRow, globalCol) += value;
                     }
                 }
             }

--- a/nuto/mechanics/cell/Assembler.h
+++ b/nuto/mechanics/cell/Assembler.h
@@ -14,11 +14,11 @@ std::vector<DofType> AvailableDofTypes(const DofVector<int> n, std::vector<DofTy
         return n.DofTypes();
 
     std::vector<DofType> intersection;
-    for (const auto& d1 : n.DofTypes())
-        for (const auto& d2 : dofTypes)
-            if (d1.Id() == d2.Id())
+    for (const auto& dofTypeRow : n.DofTypes())
+        for (const auto& dofTypeCol : dofTypes)
+            if (dofTypeRow.Id() == dofTypeCol.Id())
             {
-                intersection.push_back(d1);
+                intersection.push_back(dofTypeRow);
                 continue;
             }
     return intersection;
@@ -68,8 +68,75 @@ private:
 class MatrixAssembler
 {
 public:
+    MatrixAssembler(DofContainer<int> sizes = {})
+    {
+        Resize(sizes);
+    }
+
+    void Resize(DofContainer<int> sizes)
+    {
+        for (auto dofTypeRow : sizes)
+            for (auto dofTypeCol : sizes)
+                mMatrix(dofTypeRow.first, dofTypeCol.first).resize(dofTypeRow.second, dofTypeCol.second);
+    }
+
+    void Add(const DofMatrix<double>& m, const DofVector<int>& numbering, std::vector<DofType> dofTypes = {})
+    {
+        auto availableDofTypes = AvailableDofTypes(numbering, dofTypes);
+        for (const auto& dofTypeRow : availableDofTypes)
+        {
+            for (const auto& dofTypeCol : availableDofTypes)
+            {
+                auto& tripletListDof = mTriplets(dofTypeRow, dofTypeCol);
+                const auto& matrixDof = m(dofTypeRow, dofTypeCol);
+                const auto& numberingRow = numbering[dofTypeRow];
+                const auto& numberingCol = numbering[dofTypeCol];
+
+                for (unsigned localRow = 0; localRow < numberingRow.size(); ++localRow)
+                {
+                    for (unsigned localCol = 0; localCol < numberingCol.size(); ++localCol)
+                    {
+                        const int globalRow = numberingRow[localRow];
+                        const int globalCol = numberingCol[localCol];
+                        const double value = matrixDof(localRow, localCol);
+                        tripletListDof.push_back({globalRow, globalCol, value});
+                    }
+                }
+            }
+        }
+    }
+
+    void Reset()
+    {
+        for (auto dofTypeRow : mMatrix.DofTypes())
+            for (auto dofTypeCol : mMatrix.DofTypes())
+                mMatrix(dofTypeRow, dofTypeCol).setZero();
+    }
+
+    void Finish()
+    {
+        for (auto dofTypeRow : mMatrix.DofTypes())
+        {
+            for (auto dofTypeCol : mMatrix.DofTypes())
+            {
+                const auto& tripletListDof = mTriplets(dofTypeRow, dofTypeCol);
+                auto& matrix = mMatrix(dofTypeRow, dofTypeCol);
+                matrix.setFromTriplets(tripletListDof.begin(), tripletListDof.end());
+                matrix.makeCompressed();
+            }
+        }
+    }
+
+    const DofMatrixSparse<double>& Get() const
+    {
+        return mMatrix;
+    }
+
 private:
-    DofVector<double> mVector;
+    using TripletList = std::vector<Eigen::Triplet<double>>;
+    DofMatrixContainer<TripletList> mTriplets;
+
+    DofMatrixSparse<double> mMatrix;
 };
 
 

--- a/nuto/mechanics/dofs/DofContainer.h
+++ b/nuto/mechanics/dofs/DofContainer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <vector>
 #include "nuto/mechanics/dofs/DofType.h"
 
 namespace NuTo
@@ -19,7 +20,7 @@ public:
     //! @remark This requires T to be default constructable.
     T& operator[](DofType dofType)
     {
-        return mData[dofType.Id()];
+        return mData[dofType];
     }
 
     //! @brief nonconst access, similar to map::at()
@@ -29,7 +30,7 @@ public:
     //          require T to be default constructable.
     T& At(DofType dofType)
     {
-        return mData.at(dofType.Id());
+        return mData.at(dofType);
     }
 
     //! @brief const access
@@ -37,7 +38,7 @@ public:
     //! @return const reference to existing value, throws if there is no value
     const T& operator[](DofType dofType) const
     {
-        return mData.at(dofType.Id());
+        return mData.at(dofType);
     }
 
     //! @brief copies a `t` into the container, throws, if there already is an entry at `dofType`
@@ -45,18 +46,28 @@ public:
     //! @param t value to insert
     void Insert(DofType dofType, T t)
     {
-        auto it = mData.emplace(dofType.Id(), t); // it = pair<iterator, bool>
+        auto it = mData.emplace(dofType, t); // it = pair<iterator, bool>
         if (not it.second)
             throw Exception(__PRETTY_FUNCTION__,
                             "Insert failed. Container already contains an entry for " + dofType.GetName() + ".");
     }
 
-    bool Has(DofType dof) const
+    bool Has(DofType dofType) const
     {
-        return mData.find(dof.Id()) != mData.end();
+        return mData.find(dofType) != mData.end();
+    }
+
+    auto begin() const
+    {
+        return mData.begin();
+    }
+
+    auto end() const
+    {
+        return mData.end();
     }
 
 protected:
-    std::map<int, T> mData;
+    std::map<DofType, T, CompareDofType> mData;
 };
 } /* NuTo */

--- a/test/mechanics/cell/Assembler.cpp
+++ b/test/mechanics/cell/Assembler.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(VectorAssembly)
 
     BoostUnitTest::CheckVector(vectorAssembler.Get()[d], std::vector<double>{1, 2, 3 + 1, 2, 3}, 5);
 
-    vectorAssembler.Reset();
+    vectorAssembler.SetZero();
     BoostUnitTest::CheckVector(vectorAssembler.Get()[d], std::vector<double>{0, 0, 0, 0, 0}, 5);
 }
 
@@ -59,8 +59,10 @@ BOOST_AUTO_TEST_CASE(MatrixAssembly)
     matrixAssembler.Add(m, numbering0);
     matrixAssembler.Add(m, numbering1);
     BoostUnitTest::CheckEigenMatrix(Eigen::MatrixXd(matrixAssembler.Get()(d, d)), 2 * expected);
+    matrixAssembler.Finish(); // should not change anything
+    BoostUnitTest::CheckEigenMatrix(Eigen::MatrixXd(matrixAssembler.Get()(d, d)), 2 * expected);
 
-    matrixAssembler.Reset();
+    matrixAssembler.SetZero();
     BoostUnitTest::CheckEigenMatrix(Eigen::MatrixXd(matrixAssembler.Get()(d, d)), Eigen::MatrixXd::Zero(5, 5));
 
 

--- a/test/mechanics/cell/Assembler.cpp
+++ b/test/mechanics/cell/Assembler.cpp
@@ -24,3 +24,35 @@ BOOST_AUTO_TEST_CASE(VectorAssembly)
     vectorAssembler.Reset();
     BoostUnitTest::CheckVector(vectorAssembler.Get()[d], std::vector<double>{0, 0, 0, 0, 0}, 5);
 }
+
+
+BOOST_AUTO_TEST_CASE(MatrixAssembly)
+{
+    NuTo::DofType d("d", 1);
+    DofMatrix<double> m;
+    m(d, d).resize(3, 3);
+    m(d, d) << 11, 12, 13, 21, 22, 23, 31, 32, 33;
+
+    DofVector<int> numbering0, numbering1;
+    numbering0[d] = Eigen::Vector3i(0, 1, 2);
+    numbering1[d] = Eigen::Vector3i(2, 3, 4);
+
+    DofContainer<int> size;
+    size[d] = 5;
+    MatrixAssembler matrixAssembler(size);
+    matrixAssembler.Add(m, numbering0);
+    matrixAssembler.Add(m, numbering1);
+
+    matrixAssembler.Finish();
+
+    Eigen::MatrixXd expected(5, 5);
+    expected.setZero();
+    expected.block<3, 3>(0, 0) = m(d, d);
+    expected.block<3, 3>(2, 2) = m(d, d);
+    expected(2, 2) = 44;
+
+    BoostUnitTest::CheckEigenMatrix(Eigen::MatrixXd(matrixAssembler.Get()(d, d)), expected);
+
+    matrixAssembler.Reset();
+    BoostUnitTest::CheckEigenMatrix(Eigen::MatrixXd(matrixAssembler.Get()(d, d)), Eigen::MatrixXd::Zero(5, 5));
+}

--- a/test/mechanics/cell/Assembler.cpp
+++ b/test/mechanics/cell/Assembler.cpp
@@ -37,24 +37,32 @@ BOOST_AUTO_TEST_CASE(MatrixAssembly)
     numbering0[d] = Eigen::Vector3i(0, 1, 2);
     numbering1[d] = Eigen::Vector3i(2, 3, 4);
 
-    DofContainer<int> size;
-    size[d] = 5;
-    MatrixAssembler matrixAssembler(size);
-    matrixAssembler.Add(m, numbering0);
-    matrixAssembler.Add(m, numbering1);
-
-    matrixAssembler.Finish();
-
     Eigen::MatrixXd expected(5, 5);
     expected.setZero();
     expected.block<3, 3>(0, 0) = m(d, d);
     expected.block<3, 3>(2, 2) = m(d, d);
     expected(2, 2) = 44;
 
+    DofContainer<int> size;
+    size[d] = 5;
+
+    MatrixAssembler matrixAssembler(size);
+    matrixAssembler.Add(m, numbering0);
+    matrixAssembler.Add(m, numbering1);
+    BOOST_CHECK_THROW(matrixAssembler.Get(), Exception); // no call to  .Finish()
+    matrixAssembler.Finish();
     BoostUnitTest::CheckEigenMatrix(Eigen::MatrixXd(matrixAssembler.Get()(d, d)), expected);
+
+    // Adding the same stuff again should result in two times the expected result.
+    // As the triplet lists (used in first assembly) are dropped after callling Finish(), assembling into triplet lists
+    // again should result in `expected` instead of `2 * expected`
+    matrixAssembler.Add(m, numbering0);
+    matrixAssembler.Add(m, numbering1);
+    BoostUnitTest::CheckEigenMatrix(Eigen::MatrixXd(matrixAssembler.Get()(d, d)), 2 * expected);
 
     matrixAssembler.Reset();
     BoostUnitTest::CheckEigenMatrix(Eigen::MatrixXd(matrixAssembler.Get()(d, d)), Eigen::MatrixXd::Zero(5, 5));
+
 
     auto matrixWithNonzeros = matrixAssembler.Get();
     MatrixAssembler::Add(matrixWithNonzeros, m, numbering0);

--- a/test/mechanics/cell/Assembler.cpp
+++ b/test/mechanics/cell/Assembler.cpp
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(MatrixAssembly)
 
 
     auto matrixWithNonzeros = matrixAssembler.Get();
-    MatrixAssembler::Add(matrixWithNonzeros, m, numbering0);
-    MatrixAssembler::Add(matrixWithNonzeros, m, numbering1);
+    Assembler::Add(matrixWithNonzeros, m, numbering0);
+    Assembler::Add(matrixWithNonzeros, m, numbering1);
     BoostUnitTest::CheckEigenMatrix(Eigen::MatrixXd(matrixWithNonzeros(d, d)), expected);
 }

--- a/test/mechanics/cell/Assembler.cpp
+++ b/test/mechanics/cell/Assembler.cpp
@@ -1,0 +1,26 @@
+#include "BoostUnitTest.h"
+#include "nuto/mechanics/cell/Assembler.h"
+
+using namespace NuTo;
+
+BOOST_AUTO_TEST_CASE(VectorAssembly)
+{
+    NuTo::DofType d("d", 1);
+    DofVector<double> v;
+    v[d] = Eigen::Vector3d(1, 2, 3);
+
+    DofVector<int> numbering0, numbering1;
+    numbering0[d] = Eigen::Vector3i(0, 1, 2);
+    numbering1[d] = Eigen::Vector3i(2, 3, 4);
+
+    DofContainer<int> size;
+    size[d] = 5;
+    VectorAssembler vectorAssembler(size);
+    vectorAssembler.Add(v, numbering0);
+    vectorAssembler.Add(v, numbering1);
+
+    BoostUnitTest::CheckVector(vectorAssembler.Get()[d], std::vector<double>{1, 2, 3 + 1, 2, 3}, 5);
+
+    vectorAssembler.Reset();
+    BoostUnitTest::CheckVector(vectorAssembler.Get()[d], std::vector<double>{0, 0, 0, 0, 0}, 5);
+}

--- a/test/mechanics/cell/Assembler.cpp
+++ b/test/mechanics/cell/Assembler.cpp
@@ -55,4 +55,9 @@ BOOST_AUTO_TEST_CASE(MatrixAssembly)
 
     matrixAssembler.Reset();
     BoostUnitTest::CheckEigenMatrix(Eigen::MatrixXd(matrixAssembler.Get()(d, d)), Eigen::MatrixXd::Zero(5, 5));
+
+    auto matrixWithNonzeros = matrixAssembler.Get();
+    MatrixAssembler::Add(matrixWithNonzeros, m, numbering0);
+    MatrixAssembler::Add(matrixWithNonzeros, m, numbering1);
+    BoostUnitTest::CheckEigenMatrix(Eigen::MatrixXd(matrixWithNonzeros(d, d)), expected);
 }

--- a/test/mechanics/cell/CMakeLists.txt
+++ b/test/mechanics/cell/CMakeLists.txt
@@ -9,6 +9,8 @@ add_unit_test(CellData)
 
 add_unit_test(DifferentialOperators)
 
+add_unit_test(Assembler)
+
 add_unit_test(SimpleAssembler)
 
 add_unit_test(Matrix)


### PR DESCRIPTION
- Step towards #194
- Assembles directly into `DofVector/DofMatrixSparse` so somehow requires #164 to be 'wired' to the rest of NuTo. It may help _Team JK_ (@Psirus @joergfunger ) though.
- Advantage over `SimpleAssembler`: Option to `SetZero()` the matrix and keep the nonzero entries for the next assembly.
- remark: It has not `AddLumped` method. IMO this should somehow be done in a `LumpedCellAssembler` or something that transforms the cell-vector into a matrix and calls `MatrixAssembler::Add(...)`. Or is this too inefficient?
