### PR TITLE
Implement LinearElasticDamage for PLANE_STRESS

### DIFF
--- a/nuto/mechanics/constitutive/LinearElasticDamage.h
+++ b/nuto/mechanics/constitutive/LinearElasticDamage.h
@@ -56,9 +56,8 @@ public:
         mPinvId = mPinvDiag.asDiagonal() * (EngineeringTangent<TDim>::Identity() - mIv);
     }
 
-    LinearElasticDamage(Material::Softening m, eDamageApplication damageApplication = FULL,
-                        ePlaneState planeState = ePlaneState::PLANE_STRAIN)
-        : LinearElasticDamage::LinearElasticDamage(m.E, m.nu, damageApplication, planeState)
+    LinearElasticDamage(Material::Softening m, eDamageApplication damageApplication = FULL)
+        : LinearElasticDamage::LinearElasticDamage(m.E, m.nu, damageApplication, m.planeState)
     {
     }
 

--- a/nuto/mechanics/constitutive/damageLaws/SofteningMaterial.h
+++ b/nuto/mechanics/constitutive/damageLaws/SofteningMaterial.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../ConstitutivePlaneStateEnum.h"
+
 namespace NuTo
 {
 namespace Material
@@ -29,6 +31,9 @@ struct Softening
 
     //! residual strength [pressure]
     double fMin;
+
+    //! PLANE_STRAIN or PLANE_STRESS
+    ePlaneState planeState = ePlaneState::PLANE_STRAIN;
 };
 
 //! Sets the softening material parameters to approximate normal strength concrete

--- a/nuto/mechanics/tools/AdaptiveSolve.cpp
+++ b/nuto/mechanics/tools/AdaptiveSolve.cpp
@@ -14,10 +14,12 @@ AdaptiveSolve::AdaptiveSolve(std::function<int(double)> doStepFunction, std::fun
 {
 }
 
-void AdaptiveSolve::Solve(double tEnd)
+void AdaptiveSolve::Solve(double tEnd, double tStart)
 {
     Timer timer(__PRETTY_FUNCTION__, mPrintOutput);
-    double t = 0;
+    double t = tStart;
+    if (mPrintOutput)
+        std::cout << rang::fg::blue << "Starting adaptive solve from t = " << t << rang::style::reset << '\n';
     int iStep = 0;
 
     mPostProcess(t);

--- a/nuto/mechanics/tools/AdaptiveSolve.h
+++ b/nuto/mechanics/tools/AdaptiveSolve.h
@@ -14,12 +14,14 @@ public:
     AdaptiveSolve(std::function<int(double)> doStepFunction,
                   std::function<void(double)> postProcessFunction = [](double) {});
 
-    //! Perform an adaptive time integration from `t = 0` to `t = tEnd`.
+    //! Perform an adaptive time integration from `t = tStart` to `t = tEnd`.
     //! One time step starts at time t and tries to apply the increment dt. If the step finishes without an exception,
     //! it is finalized by updating the time to t+dt calling the postprocess function. Only NoConvergence exception will
     //! be caught. They cause a decrease in the time step.
     //! @param tEnd end time
-    void Solve(double tEnd);
+    //! @param tStart start time
+    //! @remark tStart comes second (may be unintuitive) to default it to zero.
+    void Solve(double tEnd, double tStart = 0);
 
     void SetQuiet();
 

--- a/scripts/cmake/AddBenchmark.cmake
+++ b/scripts/cmake/AddBenchmark.cmake
@@ -3,6 +3,6 @@
 function(add_benchmark BenchmarkName)
     add_executable(${BenchmarkName} ${BenchmarkName}.cpp)
     target_include_directories(${BenchmarkName} PRIVATE ${CMAKE_SOURCE_DIR}/src)
-    target_link_libraries(${BenchmarkName} benchmark::benchmark Mechanics Math Base Visualize)
+    target_link_libraries(${BenchmarkName} benchmark::benchmark NuTo)
     append_to_benchmarks(${BenchmarkName})
 endfunction()

--- a/test/mechanics/constitutive/LinearElasticDamage.cpp
+++ b/test/mechanics/constitutive/LinearElasticDamage.cpp
@@ -14,7 +14,7 @@ void CheckIsotropic(NuTo::ePlaneState planeState = NuTo::ePlaneState::PLANE_STRA
     BOOST_TEST_MESSAGE("TDim = " << TDim);
     NuTo::Laws::LinearElasticDamage<TDim> linearElasticDamage(E, nu, NuTo::Laws::FULL, planeState);
     NuTo::Laws::LinearElastic<TDim> linearElastic(E, nu, planeState);
-    NuTo::EngineeringStrain<TDim> strain = NuTo::EngineeringStrain<TDim>::Random();
+    NuTo::EngineeringStrain<TDim> strain = NuTo::EngineeringStrain<TDim>::Constant(0.1);
     double omega = 0.4;
     BoostUnitTest::CheckEigenMatrix((1. - omega) * linearElastic.Stress(strain),
                                     linearElasticDamage.Stress(strain, omega));

--- a/test/mechanics/constitutive/LinearElasticDamage.cpp
+++ b/test/mechanics/constitutive/LinearElasticDamage.cpp
@@ -9,11 +9,12 @@ constexpr double nu = 0.36;
 // https://en.wikipedia.org/wiki/Hooke%27s_law
 
 template <int TDim>
-void CheckIsotropic()
+void CheckIsotropic(NuTo::ePlaneState planeState = NuTo::ePlaneState::PLANE_STRAIN)
 {
-    NuTo::Laws::LinearElasticDamage<3> linearElasticDamage(E, nu);
-    NuTo::Laws::LinearElastic<3> linearElastic(E, nu);
-    NuTo::EngineeringStrain<3> strain = NuTo::EngineeringStrain<3>::Random();
+    BOOST_TEST_MESSAGE("TDim = " << TDim);
+    NuTo::Laws::LinearElasticDamage<TDim> linearElasticDamage(E, nu, NuTo::Laws::FULL, planeState);
+    NuTo::Laws::LinearElastic<TDim> linearElastic(E, nu, planeState);
+    NuTo::EngineeringStrain<TDim> strain = NuTo::EngineeringStrain<TDim>::Random();
     double omega = 0.4;
     BoostUnitTest::CheckEigenMatrix((1. - omega) * linearElastic.Stress(strain),
                                     linearElasticDamage.Stress(strain, omega));
@@ -27,18 +28,19 @@ void CheckIsotropic()
 BOOST_AUTO_TEST_CASE(VsLinearElastic)
 {
     CheckIsotropic<1>();
-    CheckIsotropic<2>();
+    CheckIsotropic<2>(NuTo::ePlaneState::PLANE_STRAIN);
+    CheckIsotropic<2>(NuTo::ePlaneState::PLANE_STRESS);
     CheckIsotropic<3>();
 }
 
-void CheckTangents(std::initializer_list<double> values, double omega)
+void CheckTangents(std::initializer_list<double> values, double omega, NuTo::ePlaneState planeState)
 {
     //
     // check DstressDstrain
     //
     NuTo::EngineeringStrain<2> strain = NuTo::EigenCompanion::ToEigen(values);
     BOOST_TEST_MESSAGE("Checking tangent for e = " << strain.transpose() << " and w = " << omega);
-    NuTo::Laws::LinearElasticDamage<2> law(20000, 0.2);
+    NuTo::Laws::LinearElasticDamage<2> law(20000, 0.2, NuTo::Laws::UNILATERAL, planeState);
 
     NuTo::EngineeringTangent<2> tangent = law.DstressDstrain(strain, omega);
     NuTo::EngineeringTangent<2> tangent_diff = tangent * 0.;
@@ -69,27 +71,28 @@ void CheckTangents(std::initializer_list<double> values, double omega)
 
 BOOST_AUTO_TEST_CASE(Tangent2D)
 {
-    for (double omega : {0., 0.5, 0.8})
-    {
-        CheckTangents({0, 0, 0}, omega);
+    for (auto planeState : {NuTo::ePlaneState::PLANE_STRAIN, NuTo::ePlaneState::PLANE_STRESS})
+        for (double omega : {0., 0.5, 0.8})
+        {
+            CheckTangents({0, 0, 0}, omega, planeState);
 
-        CheckTangents({2, 0, 0}, omega);
-        CheckTangents({-2, 0, 0}, omega);
-        CheckTangents({0, 2, 0}, omega);
-        CheckTangents({0, -2, 0}, omega);
-        CheckTangents({0, 0, 2}, omega);
-        CheckTangents({0, 0, -2}, omega);
+            CheckTangents({2, 0, 0}, omega, planeState);
+            CheckTangents({-2, 0, 0}, omega, planeState);
+            CheckTangents({0, 2, 0}, omega, planeState);
+            CheckTangents({0, -2, 0}, omega, planeState);
+            CheckTangents({0, 0, 2}, omega, planeState);
+            CheckTangents({0, 0, -2}, omega, planeState);
 
-        CheckTangents({1, 1, 0}, omega);
-        CheckTangents({0, 1, 1}, omega);
-        CheckTangents({1, 0, 1}, omega);
+            CheckTangents({1, 1, 0}, omega, planeState);
+            CheckTangents({0, 1, 1}, omega, planeState);
+            CheckTangents({1, 0, 1}, omega, planeState);
 
-        CheckTangents({-1, 1, 0}, omega);
-        CheckTangents({0, -1, 1}, omega);
-        CheckTangents({1, 0, -1}, omega);
+            CheckTangents({-1, 1, 0}, omega, planeState);
+            CheckTangents({0, -1, 1}, omega, planeState);
+            CheckTangents({1, 0, -1}, omega, planeState);
 
-        CheckTangents({1, -1, 0}, omega);
-        CheckTangents({0, 1, -1}, omega);
-        CheckTangents({-1, 0, 1}, omega);
-    }
+            CheckTangents({1, -1, 0}, omega, planeState);
+            CheckTangents({0, 1, -1}, omega, planeState);
+            CheckTangents({-1, 0, 1}, omega, planeState);
+        }
 }


### PR DESCRIPTION
The class performs a deviatoric/volumetric split of the stresses and strains for its calculations. This was not (super) trivial for `PLANE_STRESS` conditions since the Kronecker delta (named `D` or `mD`) for this situation differs. For `PLANE_STRAIN` you can write
~~~
eps_volumetric = 1/3 D.transpose() * strain
eps_deviatoric = strain - D * eps_volumetric
with
D.transpose() = [ 1  1  0 ] (in 2D PLANE_STRAIN)
~~~
which is, with trivial modifications, also valid for 1D and 3D.

For `PLANE_STRAIN`, we have to introduce a second Kronecker D2, namely:
~~~
eps_volumetric = 1/3 D2.transpose() * strain
eps_deviatoric = strain - D * eps_volumetric
with
D.transpose() = [ 1  1  0 ] (in 2D, always)
D2 = (1 + nu/(nu - 1)) * D (only for 2D PLANE_STRESS)
~~~

I am not :100: % sure if this is correct. But the tests
- LinearElasticDamage::Stress(strain, omega) == (1 - omega) * LinearElastic::Stress(strain)
    - (the same for all tangents, PLANE_STRAIN and PLANE_STRESS)

run smoothly.