### PR TITLE
Pde constant numbering independent of constraints

### DIFF
--- a/applications/integrationtests/mechanics/QuasistaticProblem1D.cpp
+++ b/applications/integrationtests/mechanics/QuasistaticProblem1D.cpp
@@ -110,7 +110,7 @@ private:
 
         Constraint::Constraints c;
         Constraint::Equation periodic(nodeRight, 0, Constraint::RhsRamp(1., 0.02));
-        periodic.AddTerm({nodeLeft, 0, -1});
+        periodic.AddIndependentTerm({nodeLeft, 0, -1});
 
         c.Add(disp, Constraint::Component(nodeMiddle, {eDirection::X}));
         c.Add(disp, periodic);

--- a/nuto/mechanics/constraints/ConstraintCompanion.cpp
+++ b/nuto/mechanics/constraints/ConstraintCompanion.cpp
@@ -73,7 +73,7 @@ Equation Direction(const NodeSimple& node, Eigen::VectorXd direction, RhsFunctio
     // add terms for all non zero direction components
     for (int iComponent = 0; iComponent < direction.rows(); ++iComponent)
         if (std::abs(direction[iComponent]) > 0 && iComponent != maxComponentIndex)
-            e.AddTerm(Term(node, iComponent, -direction[iComponent] / direction[maxComponentIndex]));
+            e.AddIndependentTerm(Term(node, iComponent, -direction[iComponent] / direction[maxComponentIndex]));
 
 
     return e;

--- a/nuto/mechanics/constraints/Constraints.cpp
+++ b/nuto/mechanics/constraints/Constraints.cpp
@@ -111,7 +111,7 @@ Eigen::SparseMatrix<double> Constraints::BuildUnitConstraintMatrix(DofType dof, 
 
             if (std::abs(coefficient) > 1.e-18)
                 tripletList.push_back(
-                        Eigen::Triplet<double>(numIndependentDofs + iEquation, globalDofNumber, -coefficient));
+                        Eigen::Triplet<double>(equation.GetDependentDofNumber(), globalDofNumber, -coefficient));
         }
     }
     matrix.setFromTriplets(tripletList.begin(), tripletList.end());

--- a/nuto/mechanics/constraints/Constraints.cpp
+++ b/nuto/mechanics/constraints/Constraints.cpp
@@ -84,17 +84,23 @@ Eigen::SparseMatrix<double> Constraints::BuildUnitConstraintMatrix(DofType dof, 
 
     // add unit entry for all independent dofs
     std::vector<Eigen::Triplet<double>> tripletList;
+    int curIndependent(0);
     for (auto i = 0; i < numDofs; i++)
     {
         if (isDofConstraint[i] == false)
-            tripletList.push_back(Eigen::Triplet<double>(i, i, 1.));
+        {
+            tripletList.push_back(Eigen::Triplet<double>(i, curIndependent, 1.));
+            curIndependent++;
+        }
     }
+    if (curIndependent != numIndependentDofs)
+        throw Exception(__PRETTY_FUNCTION__, "There is something wrong with the number of independent dofs.");
 
     // add entries for constraint dofs
     for (int iEquation = 0; iEquation < numEquations; ++iEquation)
     {
         const auto& equation = equations[iEquation];
-        for (Term term : equation.GetTerms())
+        for (Term term : equation.GetIndependentTerms())
         {
             double coefficient = term.GetCoefficient();
             int globalDofNumber = term.GetConstrainedDofNumber();
@@ -102,17 +108,6 @@ Eigen::SparseMatrix<double> Constraints::BuildUnitConstraintMatrix(DofType dof, 
             if (globalDofNumber == -1 /* should be NodeSimple::NOT_SET */)
                 throw Exception(__PRETTY_FUNCTION__,
                                 "There is no dof numbering for a node in equation" + std::to_string(iEquation) + ".");
-
-            if (globalDofNumber >= numIndependentDofs)
-            {
-                // This corresponds to the last block of size numDependentDofs x numDependentDofs that should be an
-                // identity matrix
-                int transformedDof = globalDofNumber - numIndependentDofs;
-                if (transformedDof != iEquation)
-                    throw Exception(__PRETTY_FUNCTION__, "The numbering of the dependent dofs "
-                                                         "is not in accordance with the equation numbering.");
-                continue; // Do not put the value into the matrix.
-            }
 
             if (std::abs(coefficient) > 1.e-18)
                 tripletList.push_back(
@@ -151,28 +146,26 @@ bool Constraints::TermChecker::TermCompare::operator()(const Term& lhs, const Te
 void Constraints::TermChecker::CheckEquation(Equation e)
 {
     // The new dependent term must not constrain the same dof as any existing terms
-    Term newDependentTerm = e.GetTerms()[0];
+    Term newDependentTerm = e.GetDependentTerm();
 
     if (Contains(mDependentTerms, newDependentTerm))
         throw Exception(__PRETTY_FUNCTION__, "The dependent dof of the new equation "
                                              "is already constrained as a dependent dof in another equation.");
 
-    if (Contains(mOtherTerms, newDependentTerm))
+    if (Contains(mIndependentTerms, newDependentTerm))
         throw Exception(__PRETTY_FUNCTION__, "The dependent dof of the new equation "
                                              "is already constrained in another equation.");
 
 
     // Any term in the new equation must not constrain the same dof as any existing _dependent_ terms
-    // since the dependent term of the new equation is already checked above, we omit it here and start loop at 1.
-    for (size_t iNewTerm = 1; iNewTerm < e.GetTerms().size(); ++iNewTerm)
+    for (auto& newTerm : e.GetIndependentTerms())
     {
-        Term newTerm = e.GetTerms()[iNewTerm];
         if (Contains(mDependentTerms, newTerm))
-            throw Exception(__PRETTY_FUNCTION__, "One of the new terms is already constrained "
+            throw Exception(__PRETTY_FUNCTION__, "One of the independent terms is already constrained "
                                                  "as a dependent dof in another equation");
     }
 
-    mDependentTerms.insert(e.GetTerms()[0]);
-    for (size_t iNewTerm = 1; iNewTerm < e.GetTerms().size(); ++iNewTerm)
-        mOtherTerms.insert(e.GetTerms()[iNewTerm]);
+    mDependentTerms.insert(e.GetDependentTerm());
+    for (auto& newTerm : e.GetIndependentTerms())
+        mIndependentTerms.insert(newTerm);
 }

--- a/nuto/mechanics/constraints/Constraints.h
+++ b/nuto/mechanics/constraints/Constraints.h
@@ -80,7 +80,7 @@ private:
         };
 
         std::set<Term, TermCompare> mDependentTerms;
-        std::set<Term, TermCompare> mOtherTerms;
+        std::set<Term, TermCompare> mIndependentTerms;
     } mTermChecker;
 };
 

--- a/nuto/mechanics/constraints/Constraints.h
+++ b/nuto/mechanics/constraints/Constraints.h
@@ -33,7 +33,7 @@ public:
     //! @brief builds the rhs of the constraint equations in a sparse global vector
     //! @param dof dof type
     //! @param numDofs total number of dofs for a specfic dof type
-    //! @param time
+    //! @param time time at which the rhs vector should be evaluated
     //! @return sparse rhs vector of the constraint equations rhs(time)
     Eigen::SparseVector<double> GetSparseGlobalRhs(DofType dof, int numDofs, double time) const;
 

--- a/nuto/mechanics/constraints/Equation.h
+++ b/nuto/mechanics/constraints/Equation.h
@@ -18,15 +18,15 @@ public:
     //! @param rhs value for the constant rhs
     Equation(const NodeSimple& dependentNode, int dependentComponent, RhsFunction rhs)
         : mRhs(rhs)
-        , mTerms{Term(dependentNode, dependentComponent, 1)}
+        , mDependentTerm(dependentNode, dependentComponent, 1)
     {
     }
 
     //! @brief adds a term to the equation
     //! @param term equation term
-    void AddTerm(Term term)
+    void AddIndependentTerm(Term term)
     {
-        mTerms.push_back(term);
+        mIndependentTerms.push_back(term);
     }
 
     //! @brief evaluates the rhs function at a given time
@@ -38,22 +38,31 @@ public:
     }
 
     //! @brief getter for mTerms
-    const std::vector<Term>& GetTerms() const
+    const Term& GetDependentTerm() const
     {
-        return mTerms;
+        return mDependentTerm;
+    }
+
+    //! @brief getter for mTerms
+    const std::vector<Term>& GetIndependentTerms() const
+    {
+        return mIndependentTerms;
     }
 
     int GetDependentDofNumber() const
     {
-        return mTerms.front().GetConstrainedDofNumber();
+        return mDependentTerm.GetConstrainedDofNumber();
     }
 
 private:
     //! @brief rhs function
     RhsFunction mRhs;
 
-    //! @brief terms
-    std::vector<Term> mTerms;
+    //! @brief dependent term rhs(t) = dependentTerm + independentTerms
+    Term mDependentTerm;
+
+    //! @brief all other terms
+    std::vector<Term> mIndependentTerms;
 };
 
 } /* Constaint */

--- a/nuto/mechanics/tools/QuasistaticSolver.h
+++ b/nuto/mechanics/tools/QuasistaticSolver.h
@@ -28,7 +28,7 @@ public:
     void SetGlobalTime(double globalTime);
 
     //! computes the trial state of the system
-    //! @param newGlobalTime
+    //! @param newGlobalTime new time, for which the trial state is to be computed
     //! @param solver that allows to extract the constraint displacements from previous steps
     DofVector<double> TrialState(double newGlobalTime, const NuTo::ConstrainedSystemSolver& solver);
 

--- a/test/mechanics/constraints/Constraints.cpp
+++ b/test/mechanics/constraints/Constraints.cpp
@@ -54,6 +54,7 @@ BOOST_AUTO_TEST_CASE(ConstraintCMatrixInteracting)
     NodeSimple node2(0);
     NodeSimple node3(0);
     NodeSimple node4(0);
+    NodeSimple node5(0);
 
     /*
      *     n0 ---- n1 ---- n2 ---- n3 --- n4
@@ -65,17 +66,19 @@ BOOST_AUTO_TEST_CASE(ConstraintCMatrixInteracting)
      *  [42  0  0 ] (n2) + [ 0  1 ] (n4) = rhs;
      *
      */
-    Eigen::MatrixXd cmatUnitExpected = Eigen::MatrixXd::Zero(5, 3);
+    Eigen::MatrixXd cmatUnitExpected = Eigen::MatrixXd::Zero(6, 4);
     cmatUnitExpected(0, 0) = 1;
     cmatUnitExpected(1, 1) = 1;
     cmatUnitExpected(2, 2) = 1;
     cmatUnitExpected(4, 0) = -42;
+    cmatUnitExpected(5, 3) = 1;
 
     node0.SetDofNumber(0, 0);
     node1.SetDofNumber(0, 1);
     node2.SetDofNumber(0, 2);
     node3.SetDofNumber(0, 3);
     node4.SetDofNumber(0, 4);
+    node5.SetDofNumber(0, 5);
 
     Equation noninteractingEquation(node3, 0, rhs);
 
@@ -86,7 +89,7 @@ BOOST_AUTO_TEST_CASE(ConstraintCMatrixInteracting)
     c.Add(dof, noninteractingEquation);
     c.Add(dof, interactingEquation);
 
-    Eigen::MatrixXd cmatUnit = c.BuildUnitConstraintMatrix(dof, 5);
+    Eigen::MatrixXd cmatUnit = c.BuildUnitConstraintMatrix(dof, 6);
 
     std::cout << "cmatUnitExpected\n" << cmatUnitExpected << std::endl;
     std::cout << "cmatUnit\n" << cmatUnit << std::endl;

--- a/test/mechanics/constraints/Constraints.cpp
+++ b/test/mechanics/constraints/Constraints.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(ConstraintCMatrixInteracting)
     Equation noninteractingEquation(node3, 0, rhs);
 
     Equation interactingEquation(node4, 0, rhs);
-    interactingEquation.AddTerm({node0, 0, 42});
+    interactingEquation.AddIndependentTerm({node0, 0, 42});
 
     Constraints c;
     c.Add(dof, noninteractingEquation);
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(ConstraintTwoDependentDofsInOneEquation)
     constraints.Add(dof, {node, 0, rhs}); // node.dof0 * 1.0 = rhs
 
     Constraint::Equation equation(node, 1, rhs);
-    equation.AddTerm({node, 0, 0.4}); // node.dof1 * 1.0 + node.dof0 * 0.4 = rhs
+    equation.AddIndependentTerm({node, 0, 0.4}); // node.dof1 * 1.0 + node.dof0 * 0.4 = rhs
     BOOST_CHECK_THROW(constraints.Add(dof, equation), Exception);
 }
 

--- a/test/mechanics/dofs/DofNumbering.cpp
+++ b/test/mechanics/dofs/DofNumbering.cpp
@@ -33,12 +33,9 @@ BOOST_AUTO_TEST_CASE(DofNumberingTest)
 
     // Check if unconstrained nodes have dof number [0..3], ordering does not matter
     std::vector<int> dofNumbersUnconstrained{nodeUnconstrained0.GetDofNumber(0), nodeUnconstrained0.GetDofNumber(1),
-                                             nodeUnconstrained1.GetDofNumber(0), nodeUnconstrained1.GetDofNumber(1)};
-    BOOST_CHECK(IsPermutation(dofNumbersUnconstrained, {0, 1, 2, 3}));
-
-    // Check if constrained nodes have dof number [5, 4], ordering has to be in the order of the equation definition
-    BOOST_CHECK_EQUAL(nodeConstrained.GetDofNumber(0), 5);
-    BOOST_CHECK_EQUAL(nodeConstrained.GetDofNumber(1), 4);
+                                             nodeUnconstrained1.GetDofNumber(0), nodeUnconstrained1.GetDofNumber(1),
+                                             nodeConstrained.GetDofNumber(0),    nodeConstrained.GetDofNumber(1)};
+    BOOST_CHECK(IsPermutation(dofNumbersUnconstrained, {0, 1, 2, 3, 4, 5}));
 }
 
 BOOST_AUTO_TEST_CASE(InvalidDofTypes)


### PR DESCRIPTION
In the already merged removeJK branch, there was still the renumbering based on the constraints included. This is no longer required, and was now removed here. While implementing this, I realized that in almost all cases, when we loop over the constraint equations, we either need the dependent term or the  independent terms, never both. Also, every equation should have  one single dependent term. As a consequence, I have split the terms in equation into the dependent term that is always set in the constructor, and the (now called independent) terms that are the other terms. That requires some changes, i.e. constraintEquation.AddTerm has to be replaced by constraintEquation.AddIndependentTerm. I could have also not renamed this, however I thought this would be clearer for people who used this functionality and with the renaming are aware that the first term in this list is no longer the dependent term.