### PR TITLE
Fix AverageGeometries

### DIFF
--- a/nuto/visualize/AverageGeometries.h
+++ b/nuto/visualize/AverageGeometries.h
@@ -19,23 +19,24 @@ struct AverageGeometry
 //! @return quad geometry from (-1,-1) to (1,1)
 inline AverageGeometry AverageGeometryLine()
 {
-    std::vector<Eigen::VectorXd> cornerCoordinates = {Eigen::Vector3d(-1, 0, 0), Eigen::Vector3d(1, 0, 0)};
+    std::vector<Eigen::VectorXd> cornerCoordinates = {Eigen::VectorXd::Constant(1, -1),
+                                                      Eigen::VectorXd::Constant(1, 1)};
     return {cornerCoordinates, eCellTypes::LINE};
 }
 
 //! @return quad geometry from (-1,-1) to (1,1)
 inline AverageGeometry AverageGeometryQuad()
 {
-    std::vector<Eigen::VectorXd> cornerCoordinates = {Eigen::Vector3d(-1, -1, 0), Eigen::Vector3d(1, -1, 0),
-                                                      Eigen::Vector3d(1, 1, 0), Eigen::Vector3d(-1, 1, 0)};
+    std::vector<Eigen::VectorXd> cornerCoordinates = {Eigen::Vector2d(-1, -1), Eigen::Vector2d(1, -1),
+                                                      Eigen::Vector2d(1, 1), Eigen::Vector2d(-1, 1)};
     return {cornerCoordinates, eCellTypes::QUAD};
 }
 
 //! @return triangle geometry (0,0 -- 1,0 -- 0,1)
 inline AverageGeometry AverageGeometryTriangle()
 {
-    std::vector<Eigen::VectorXd> cornerCoordinates = {Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(1, 0, 0),
-                                                      Eigen::Vector3d(0, 1, 0)};
+    std::vector<Eigen::VectorXd> cornerCoordinates = {Eigen::Vector2d(0, 0), Eigen::Vector2d(1, 0),
+                                                      Eigen::Vector2d(0, 1)};
     return {cornerCoordinates, eCellTypes::TRIANGLE};
 }
 


### PR DESCRIPTION
1D or 2D interpolations may require local point coordinates to be
1D or 2D. Before all were 3D. Eigen will then complain in debug mode
if you want to average-visualize e.g. a LobattoQuadCell.