### PR TITLE
Include eigen_algebra_dispatcher in odeint helper

### DIFF
--- a/applications/integrationtests/math/HarmonicOscillator.cpp
+++ b/applications/integrationtests/math/HarmonicOscillator.cpp
@@ -59,7 +59,7 @@ int main()
     std::vector<Eigen::VectorXd> x_vec;
     std::vector<double> times;
 
-    runge_kutta_cash_karp54<Eigen::VectorXd, double, Eigen::VectorXd, double, vector_space_algebra> stepper;
+    runge_kutta_cash_karp54<Eigen::VectorXd> stepper;
 
     double t0 = 0.;
     double tF = 5.;

--- a/nuto/math/EigenOdeintCompatibility.h
+++ b/nuto/math/EigenOdeintCompatibility.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <boost/numeric/odeint/algebra/vector_space_algebra.hpp>
+#include <boost/numeric/odeint/external/eigen/eigen_algebra_dispatcher.hpp>
 #include <boost/numeric/odeint/external/eigen/eigen_resize.hpp>
 
 namespace Eigen


### PR DESCRIPTION
This will allow declaring steppers without supplying the
`vector_space_algebra` template parameter.

I really wish I hadn't merged the old one so quickly...