### PR TITLE
Pde jacobian exceptions

### DIFF
--- a/nuto/mechanics/cell/Cell.h
+++ b/nuto/mechanics/cell/Cell.h
@@ -51,8 +51,7 @@ public:
         {
             auto ipCoords = mIntegrationType.GetLocalIntegrationPointCoordinates(iIP);
             Jacobian jacobian(mElements.CoordinateElement().ExtractNodeValues(),
-                              mElements.CoordinateElement().GetDerivativeShapeFunctions(ipCoords),
-                              mElements.CoordinateElement().GetDofDimension());
+                              mElements.CoordinateElement().GetDerivativeShapeFunctions(ipCoords));
             CellIpData cellipData(cellData, jacobian, ipCoords, iIP);
             f(cellipData);
         }
@@ -86,8 +85,7 @@ public:
         {
             auto ipCoords = mIntegrationType.GetLocalIntegrationPointCoordinates(iIP);
             Jacobian jacobian(mElements.CoordinateElement().ExtractNodeValues(),
-                              mElements.CoordinateElement().GetDerivativeShapeFunctions(ipCoords),
-                              mElements.CoordinateElement().GetDofDimension());
+                              mElements.CoordinateElement().GetDerivativeShapeFunctions(ipCoords));
             CellIpData cellipData(cellData, jacobian, ipCoords, iIP);
             result.push_back(f(cellipData));
         }
@@ -113,8 +111,7 @@ private:
             auto ipCoords = mIntegrationType.GetLocalIntegrationPointCoordinates(iIP);
             auto ipWeight = mIntegrationType.GetIntegrationPointWeight(iIP);
             Jacobian jacobian(mElements.CoordinateElement().ExtractNodeValues(),
-                              mElements.CoordinateElement().GetDerivativeShapeFunctions(ipCoords),
-                              mElements.CoordinateElement().GetDofDimension());
+                              mElements.CoordinateElement().GetDerivativeShapeFunctions(ipCoords));
             CellIpData cellipData(cellData, jacobian, ipCoords, iIP);
             result += f(cellipData) * jacobian.Det() * ipWeight;
         }

--- a/nuto/mechanics/cell/Jacobian.h
+++ b/nuto/mechanics/cell/Jacobian.h
@@ -13,10 +13,11 @@ public:
     using Dynamic3by3 = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor, 3, 3>;
     using Dynamic3by1 = Eigen::Matrix<double, Eigen::Dynamic, 1, Eigen::ColMajor, 3, 1>;
 
-    Jacobian(const Eigen::VectorXd& nodeValues, const Eigen::MatrixXd& derivativeShapeFunctions, int globalDimension)
+    Jacobian(const Eigen::VectorXd& nodeValues, const Eigen::MatrixXd& derivativeShapeFunctions)
     {
         const int interpolationDimension = derivativeShapeFunctions.cols();
-        // case 1: global dimension ( node dimension ) matches the interpolation dimension.
+        const int numNodes = derivativeShapeFunctions.rows();
+        const int globalDimension = nodeValues.rows() / numNodes;
         if (interpolationDimension == globalDimension)
         {
             switch (globalDimension)

--- a/nuto/mechanics/cell/Jacobian.h
+++ b/nuto/mechanics/cell/Jacobian.h
@@ -79,13 +79,20 @@ public:
             }
             default:
             {
-                throw;
+                throw Exception(__PRETTY_FUNCTION__,
+                                "Global dimension should be 2 or 3 for codimension 1 objects, got: " +
+                                        std::to_string(globalDimension) + ".");
             }
             }
         }
         else
         {
-            throw;
+            throw Exception(__PRETTY_FUNCTION__,
+                            "Jacobian only implemented for interpolationDimension equal to globaldimension or one "
+                            "less, got: \n"
+                            "InterpolationDimension: " +
+                                    std::to_string(interpolationDimension) + "\n" +
+                                    "GlobalDimension: " + std::to_string(globalDimension));
         }
     }
 

--- a/nuto/mechanics/elements/ElementInterface.h
+++ b/nuto/mechanics/elements/ElementInterface.h
@@ -11,6 +11,10 @@ public:
     virtual ~ElementInterface() noexcept = default;
 
     //! @brief extracts all node values of this element
+    //!
+    //! They are ordered in blocks belonging to a node, e.g:
+    //! coordinate Nodes in 3D:
+    //!   NodeValues: (x1,y1,z1, x2,y2,z2, ...)
     virtual Eigen::VectorXd ExtractNodeValues(int instance = 0) const = 0;
 
     virtual int GetDofDimension() const = 0;

--- a/test/mechanics/cell/CMakeLists.txt
+++ b/test/mechanics/cell/CMakeLists.txt
@@ -8,6 +8,7 @@ add_unit_test(Jacobian
     mechanics/interpolation/InterpolationTrussQuadratic.cpp
     mechanics/interpolation/InterpolationTriangleLinear.cpp
     mechanics/interpolation/InterpolationQuadLinear.cpp
+    mechanics/interpolation/InterpolationBrickLinear.cpp
     mechanics/interpolation/InterpolationTetrahedronLinear.cpp
     )
 

--- a/test/mechanics/cell/CellIpData.cpp
+++ b/test/mechanics/cell/CellIpData.cpp
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE(CellIpDataMemoizationB)
 
     NuTo::NaturalCoords ipCoords = Eigen::Vector2d({1. / 3., 1. / 3.});
 
-    NuTo::Jacobian jac(nodalValues, dNdXi, 2);
+    NuTo::Jacobian jac(nodalValues, dNdXi);
     NuTo::CellData cellData(elements.get(), 0);
     NuTo::CellIpData ipData(cellData, jac, ipCoords, 0);
 

--- a/test/mechanics/cell/Jacobian.cpp
+++ b/test/mechanics/cell/Jacobian.cpp
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE(Jacobian1DDet)
 {
     Eigen::MatrixXd B = InterpolationTrussLinear::DerivativeShapeFunctions();
     Eigen::VectorXd coordinates = Eigen::Vector2d({12., 17});
-    Jacobian jacobian(coordinates, B, 1);
+    Jacobian jacobian(coordinates, B);
     BOOST_CHECK_CLOSE(jacobian.Det(), 2.5, 1.e-10);
 }
 
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(Jacobian2DDet)
     coordinates << 0, 0, 2, 0, 2, 8, 0, 8; // rectangle from (0,0) to (2,8)
 
 
-    Jacobian jacobian(coordinates, B, 2);
+    Jacobian jacobian(coordinates, B);
     BOOST_CHECK_CLOSE(jacobian.Det(), 4, 1.e-10); // reference area = 4, this area = 16;
 }
 
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(Jacobian3DDet)
     Eigen::VectorXd coordinates = Eigen::VectorXd(12);
     coordinates << 0, 0, 0, 10, 0, 0, 0, 5, 0, 0, 0, 42;
 
-    Jacobian jacobian(coordinates, B, 3);
+    Jacobian jacobian(coordinates, B);
     BOOST_CHECK_CLOSE(jacobian.Det(), 10 * 5 * 42, 1.e-10);
 }
 
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(Jacobian1Din2D)
         Eigen::VectorXd coordinates = Eigen::VectorXd(4);
         coordinates << 0, 0, 3, 4;
 
-        Jacobian jacobian(coordinates, B, 2);
+        Jacobian jacobian(coordinates, B);
         BOOST_CHECK_CLOSE(jacobian.Det() * 2, 5, 1.e-10);
         //
         // total length of the element is 5 = sqrt(3*3 + 4*4)
@@ -60,8 +60,8 @@ BOOST_AUTO_TEST_CASE(Jacobian1Din2D)
                 Eigen::VectorXd::Constant(1, -std::sqrt(1. / 3.)));
         Eigen::MatrixXd B1 =
                 InterpolationTrussQuadratic::DerivativeShapeFunctions(Eigen::VectorXd::Constant(1, std::sqrt(1. / 3.)));
-        Jacobian jacobian0(coordinates, B0, 2);
-        Jacobian jacobian1(coordinates, B1, 2);
+        Jacobian jacobian0(coordinates, B0);
+        Jacobian jacobian1(coordinates, B1);
         BOOST_CHECK_CLOSE(jacobian0.Det() + jacobian1.Det(), 5, 1.e-10);
         //
         // total length of the element is 5 = sqrt(3*3 + 4*4)
@@ -76,7 +76,7 @@ double TriangleAreaViaJacobian(Eigen::Vector3d a, Eigen::Vector3d b, Eigen::Vect
     Eigen::VectorXd coordinates = Eigen::VectorXd(9);
     coordinates << a.x(), a.y(), a.z(), b.x(), b.y(), b.z(), c.x(), c.y(), c.z();
 
-    Jacobian jacobian(coordinates, B, 3);
+    Jacobian jacobian(coordinates, B);
 
     double ratioAreaRealToAreaNatural = jacobian.Det();
     double areaNatural = 0.5; // triangle (0,0) ; (1,0) ; (0,1)
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(Jacobian2Din3DComputeNormal)
     Eigen::VectorXd coordinates = Eigen::VectorXd(9);
     coordinates << p1, p2, p3;
 
-    Jacobian jacobian(coordinates, B, 3);
+    Jacobian jacobian(coordinates, B);
 
     Eigen::Vector3d normal = jacobian.Normal();
     double expectedNormalComponents = 1. / sqrt(3.);
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(Jacobian1Din2DComputeNormal)
     Eigen::VectorXd coordinates = Eigen::VectorXd(4);
     coordinates << p1, p2;
 
-    Jacobian jacobian(coordinates, B, 2);
+    Jacobian jacobian(coordinates, B);
 
     Eigen::Vector2d normal = jacobian.Normal();
     double expectedNormalComponents = 1. / sqrt(2.);
@@ -138,6 +138,5 @@ BOOST_AUTO_TEST_CASE(JacobianExceptions)
 {
     Eigen::MatrixXd B = InterpolationBrickLinear::DerivativeShapeFunctions(Eigen::Vector3d(0., 0., 0.));
     Eigen::Vector3d coordinates(1., 2., 3.);
-    BOOST_CHECK_THROW(Jacobian jacobian(coordinates, B, 4), Exception);
-    BOOST_CHECK_THROW(Jacobian jacobian(coordinates, B, 2), Exception);
+    BOOST_CHECK_THROW(Jacobian jacobian(coordinates, B), Exception);
 }

--- a/test/mechanics/cell/Jacobian.cpp
+++ b/test/mechanics/cell/Jacobian.cpp
@@ -5,6 +5,7 @@
 #include "nuto/mechanics/interpolation/InterpolationTrussQuadratic.h"
 #include "nuto/mechanics/interpolation/InterpolationTriangleLinear.h"
 #include "nuto/mechanics/interpolation/InterpolationQuadLinear.h"
+#include "nuto/mechanics/interpolation/InterpolationBrickLinear.h"
 #include "nuto/mechanics/interpolation/InterpolationTetrahedronLinear.h"
 
 using namespace NuTo;
@@ -131,4 +132,12 @@ BOOST_AUTO_TEST_CASE(Jacobian1Din2DComputeNormal)
 BOOST_AUTO_TEST_CASE(JacobianTransform)
 {
     // TODO! How?
+}
+
+BOOST_AUTO_TEST_CASE(JacobianExceptions)
+{
+    Eigen::MatrixXd B = InterpolationBrickLinear::DerivativeShapeFunctions(Eigen::Vector3d(0., 0., 0.));
+    Eigen::Vector3d coordinates(1., 2., 3.);
+    BOOST_CHECK_THROW(Jacobian jacobian(coordinates, B, 4), Exception);
+    BOOST_CHECK_THROW(Jacobian jacobian(coordinates, B, 2), Exception);
 }

--- a/test/mechanics/integrands/GradientDamage.cpp
+++ b/test/mechanics/integrands/GradientDamage.cpp
@@ -21,7 +21,7 @@ void CheckHessian0(ElementCollectionFem& element, Integrands::GradientDamage<1>&
     CellData cellData(element, 0);
     Eigen::VectorXd ip = Eigen::Vector2d::Ones() * 0.67124;
     Jacobian jac(element.CoordinateElement().ExtractNodeValues(),
-                 element.CoordinateElement().GetDerivativeShapeFunctions(ip), 1);
+                 element.CoordinateElement().GetDerivativeShapeFunctions(ip));
 
     CellIpData cipd(cellData, jac, ip, 0);
 

--- a/test/mechanics/integrands/NeumannBc.cpp
+++ b/test/mechanics/integrands/NeumannBc.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(NeumannBc1Din2D)
 
     CellData cellData(element, cellID);
     Jacobian dummyJac(element.CoordinateElement().ExtractNodeValues(), // jacobian not needed for N.
-                      element.CoordinateElement().GetDerivativeShapeFunctions(Eigen::VectorXd::Constant(1, 0.)), 2);
+                      element.CoordinateElement().GetDerivativeShapeFunctions(Eigen::VectorXd::Constant(1, 0.)));
 
 
     // Gradient. What should happen here?
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(NeumannBc2Din3D)
 
     CellData cellData(element, cellID);
     Jacobian dummyJac(element.CoordinateElement().ExtractNodeValues(), // jacobian not needed for N.
-                      element.CoordinateElement().GetDerivativeShapeFunctions(Eigen::VectorXd::Constant(2, 1, 0.)), 3);
+                      element.CoordinateElement().GetDerivativeShapeFunctions(Eigen::VectorXd::Constant(2, 1, 0.)));
 
     std::vector<Eigen::Vector2d> points;
     points.push_back(Eigen::Vector2d(1. / 6., 1. / 6.));

--- a/test/mechanics/mesh/MeshGmsh.cpp
+++ b/test/mechanics/mesh/MeshGmsh.cpp
@@ -35,8 +35,7 @@ void CheckMesh(std::string meshFile, int numNodesExpected)
     for (int iNode = 0; iNode < interpolation.GetNumNodes(); ++iNode)
     {
         auto coord = interpolation.GetLocalCoords(iNode);
-        int globalDimension = coord.rows();
-        Jacobian j(element.ExtractNodeValues(), interpolation.GetDerivativeShapeFunctions(coord), globalDimension);
+        Jacobian j(element.ExtractNodeValues(), interpolation.GetDerivativeShapeFunctions(coord));
         bool isPositiveForINode = j.Det() > -1.e-10;
         if (iNode == 0)
             isPositive = isPositiveForINode;

--- a/test/mechanics/mesh/UnitMeshFem.cpp
+++ b/test/mechanics/mesh/UnitMeshFem.cpp
@@ -10,7 +10,7 @@ void CheckJacobians(NuTo::MeshFem& mesh)
     {
         auto d_dxi = element.CoordinateElement().GetDerivativeShapeFunctions(ip);
         auto x = element.CoordinateElement().ExtractNodeValues();
-        auto J = NuTo::Jacobian(x, d_dxi, dim);
+        auto J = NuTo::Jacobian(x, d_dxi);
         BOOST_CHECK_GT(J.Det(), 0.);
     }
 }


### PR DESCRIPTION
- Add messages for Exception throws. 
- Remove globalDimension as constructor argument since it can be deduced from _nodalValues_ and _derivativeShapefunctions_ (the other arguments)