### PR TITLE
Add ability to create Debian packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,3 +43,7 @@ install(EXPORT NuToTargets
     NAMESPACE NuTo::
     DESTINATION lib/cmake/NuTo
     )
+
+set(CPACK_GENERATOR "DEB")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "christoph.pohl@bam.de")
+include(CPack)

--- a/scripts/check_install.sh
+++ b/scripts/check_install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ev
-echo nuto | sudo -S make install
+make package
+echo nuto | sudo -S dpkg -i NuTo-0.1.1-Linux.deb
 mkdir -p testproject && cd testproject
 printf "project(testproject)\ncmake_minimum_required(VERSION 3.5)\nset(CMAKE_CXX_STANDARD 14)\nfind_package(NuTo)\nadd_executable(printVersion printVersion.cpp)\ntarget_link_libraries(printVersion NuTo::NuTo)" > CMakeLists.txt
 printf "#include <iostream>\n#include <nuto/base/Version.h>\n#include <Eigen/Core>\nint main(){\nstd::cout << NuTo::Version << std::endl;\nreturn 0;\n}" > printVersion.cpp


### PR DESCRIPTION
This will add a target `package` that generates a .deb package of NuTo. That can than be installed with `dpkg -i <packageName>.deb`. The advantage is that you can easily uninstall (`sudo apt remove nuto`) the files compared to the `make install` way.