### PR TITLE
Separate geometry and dofs/interpolation

### DIFF
--- a/applications/benchmark/CMakeLists.txt
+++ b/applications/benchmark/CMakeLists.txt
@@ -6,7 +6,7 @@ add_benchmark(BuildGradient)
 
 add_benchmark(ConstraintsBenchmark)
 
-add_benchmark(DofMatrixExport)
+#add_benchmark(DofMatrixExport)
 
 add_benchmark(MeshFemBenchmark)
 

--- a/applications/examples/GradientDamageCalibration.cpp
+++ b/applications/examples/GradientDamageCalibration.cpp
@@ -69,7 +69,6 @@ double GlobalFractureEnergy(TGdm& gdm, Material::Softening material, double L = 
     equations.AddUpdateFunction(cells, TimeDependentProblem::Bind(gdm, &TGdm::Update));
 
     QuasistaticSolver problem(equations, {d, eeq});
-    problem.SetQuiet();
     problem.mTolerance = 1.e-6;
     problem.SetConstraints(constraints);
 
@@ -81,7 +80,6 @@ double GlobalFractureEnergy(TGdm& gdm, Material::Softening material, double L = 
     auto postProcessF = [&](double) { problem.WriteTimeDofResidual(loadDisplacement, d, {dofLeft}); };
 
     AdaptiveSolve adaptiveSolve(doStep, postProcessF);
-    adaptiveSolve.SetQuiet();
     adaptiveSolve.dt = 0.01;
     adaptiveSolve.dtMin = 1.e-10;
     adaptiveSolve.dtMax = 0.01;

--- a/applications/examples/GradientDamageCalibration.cpp
+++ b/applications/examples/GradientDamageCalibration.cpp
@@ -7,6 +7,7 @@
 #include "nuto/mechanics/integrands/GradientDamage.h"
 #include "nuto/mechanics/constitutive/damageLaws/DamageLawExponential.h"
 #include "nuto/mechanics/mesh/UnitMeshFem.h"
+#include "nuto/mechanics/mesh/GeometryMeshFem.h"
 #include "nuto/mechanics/mesh/MeshFemDofConvert.h"
 #include "nuto/mechanics/interpolation/InterpolationTrussLobatto.h"
 #include "nuto/mechanics/integrationtypes/IntegrationTypeTensorProduct.h"
@@ -38,8 +39,10 @@ double GlobalFractureEnergy(TGdm& gdm, Material::Softening material, double L = 
     DofType d = gdm.mDisp;
     ScalarDofType eeq = gdm.mEeq;
 
-    MeshFem mesh = UnitMeshFem::Transform(UnitMeshFem::CreateLines(nElements),
-                                          [&](Eigen::VectorXd x) { return Eigen::VectorXd::Constant(1, x[0] * L); });
+    GeometryMeshFem geoMesh = UnitMeshFem::Transform(UnitMeshFem::CreateLines(nElements), [&](Eigen::VectorXd x) {
+        return Eigen::VectorXd::Constant(1, x[0] * L);
+    });
+    MeshFem mesh(geoMesh);
 
     InterpolationTrussLobatto interpolationD(2);
     AddDofInterpolation(&mesh, d, interpolationD);

--- a/applications/integrationtests/mechanics/CSDAInterface.cpp
+++ b/applications/integrationtests/mechanics/CSDAInterface.cpp
@@ -43,11 +43,11 @@ void CheckFractureEnergy2D(int angleDegree, double interfaceThickness)
     std::cout << "interfaceLength " << interfaceLength << '\n';
 
     // lower nodes
-    NuTo::NodeSimple n0(Eigen::Vector2d({-xInterfaceOffset - projectedThickness / 2., -ly2}));
-    NuTo::NodeSimple n1(Eigen::Vector2d({-xInterfaceOffset + projectedThickness / 2., -ly2}));
+    NuTo::NodeCoordinates n0(Eigen::Vector2d({-xInterfaceOffset - projectedThickness / 2., -ly2}));
+    NuTo::NodeCoordinates n1(Eigen::Vector2d({-xInterfaceOffset + projectedThickness / 2., -ly2}));
     // upper nodes
-    NuTo::NodeSimple n2(Eigen::Vector2d({+xInterfaceOffset + projectedThickness / 2., ly2}));
-    NuTo::NodeSimple n3(Eigen::Vector2d({+xInterfaceOffset - projectedThickness / 2., ly2}));
+    NuTo::NodeCoordinates n2(Eigen::Vector2d({+xInterfaceOffset + projectedThickness / 2., ly2}));
+    NuTo::NodeCoordinates n3(Eigen::Vector2d({+xInterfaceOffset - projectedThickness / 2., ly2}));
 
     NuTo::NodeSimple nd0(Eigen::Vector2d::Zero());
     NuTo::NodeSimple nd1(Eigen::Vector2d::Zero());

--- a/applications/integrationtests/mechanics/CSDAInterface.cpp
+++ b/applications/integrationtests/mechanics/CSDAInterface.cpp
@@ -55,7 +55,8 @@ void CheckFractureEnergy2D(int angleDegree, double interfaceThickness)
     NuTo::DofNode nd3(Eigen::Vector2d::Zero());
     NuTo::InterpolationQuadLinear interpolation;
 
-    NuTo::ElementCollectionFem element({{n0, n1, n2, n3}, interpolation});
+    NuTo::CoordinateElementFem cElm{{n0, n1, n2, n3}, interpolation};
+    NuTo::ElementCollectionFem element(cElm);
     NuTo::DofType d("Displ", 2);
     element.AddDofElement(d, {{nd0, nd1, nd2, nd3}, interpolation});
 

--- a/applications/integrationtests/mechanics/CSDAInterface.cpp
+++ b/applications/integrationtests/mechanics/CSDAInterface.cpp
@@ -43,16 +43,16 @@ void CheckFractureEnergy2D(int angleDegree, double interfaceThickness)
     std::cout << "interfaceLength " << interfaceLength << '\n';
 
     // lower nodes
-    NuTo::NodeCoordinates n0(Eigen::Vector2d({-xInterfaceOffset - projectedThickness / 2., -ly2}));
-    NuTo::NodeCoordinates n1(Eigen::Vector2d({-xInterfaceOffset + projectedThickness / 2., -ly2}));
+    NuTo::CoordinateNode n0(Eigen::Vector2d({-xInterfaceOffset - projectedThickness / 2., -ly2}));
+    NuTo::CoordinateNode n1(Eigen::Vector2d({-xInterfaceOffset + projectedThickness / 2., -ly2}));
     // upper nodes
-    NuTo::NodeCoordinates n2(Eigen::Vector2d({+xInterfaceOffset + projectedThickness / 2., ly2}));
-    NuTo::NodeCoordinates n3(Eigen::Vector2d({+xInterfaceOffset - projectedThickness / 2., ly2}));
+    NuTo::CoordinateNode n2(Eigen::Vector2d({+xInterfaceOffset + projectedThickness / 2., ly2}));
+    NuTo::CoordinateNode n3(Eigen::Vector2d({+xInterfaceOffset - projectedThickness / 2., ly2}));
 
-    NuTo::NodeSimple nd0(Eigen::Vector2d::Zero());
-    NuTo::NodeSimple nd1(Eigen::Vector2d::Zero());
-    NuTo::NodeSimple nd2(Eigen::Vector2d::Zero());
-    NuTo::NodeSimple nd3(Eigen::Vector2d::Zero());
+    NuTo::DofNode nd0(Eigen::Vector2d::Zero());
+    NuTo::DofNode nd1(Eigen::Vector2d::Zero());
+    NuTo::DofNode nd2(Eigen::Vector2d::Zero());
+    NuTo::DofNode nd3(Eigen::Vector2d::Zero());
     NuTo::InterpolationQuadLinear interpolation;
 
     NuTo::ElementCollectionFem element({{n0, n1, n2, n3}, interpolation});

--- a/applications/integrationtests/mechanics/CreepLaw.cpp
+++ b/applications/integrationtests/mechanics/CreepLaw.cpp
@@ -17,7 +17,7 @@
 #include "nuto/mechanics/mesh/MeshFem.h"
 #include "nuto/mechanics/mesh/MeshFemDofConvert.h"
 #include "nuto/mechanics/mesh/UnitMeshFem.h"
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 
 #include <cassert>
 #include <functional>
@@ -280,9 +280,10 @@ BOOST_AUTO_TEST_CASE(History_Data)
 
     // Build external Force %%%%%%%%%%%%%%%%%%%%%
     constexpr double rhsForce = 2000.;
+
     DofVector<double> extF;
     extF[displ].setZero(dofInfo.numIndependentDofs[displ] + dofInfo.numDependentDofs[displ]);
-    NodeSimple& nodeRight = mesh.NodeAtCoordinate(Eigen::VectorXd::Ones(1) * SpecimenLength, displ);
+    DofNode& nodeRight = mesh.NodeAtCoordinate(Eigen::VectorXd::Ones(1) * SpecimenLength, displ);
     extF[displ][nodeRight.GetDofNumber(0)] = rhsForce;
 
     // Post processing stuff %%%%%%%%%%%%%%%%%%%%
@@ -325,7 +326,12 @@ BOOST_AUTO_TEST_CASE(History_Data)
             solution[displ] += deltaDisplacements;
 
             // Merge dof values %%%%%%%%%%%%%%%%%
+<<<<<<< HEAD
             for (NodeSimple& node : mesh.NodesTotal(displ))
+=======
+            int numUnconstrainedDofs = dofInfo.numIndependentDofs[displ];
+            for (DofNode& node : mesh.NodesTotal(displ))
+>>>>>>> Rename Nodes to DofNode and CoordinateNode
             {
                 int dofNumber = node.GetDofNumber(0);
                 node.SetValue(0, solution[displ][dofNumber]);

--- a/applications/integrationtests/mechanics/CreepLaw.cpp
+++ b/applications/integrationtests/mechanics/CreepLaw.cpp
@@ -328,19 +328,11 @@ BOOST_AUTO_TEST_CASE(History_Data)
             solution[displ] += deltaDisplacements;
 
             // Merge dof values %%%%%%%%%%%%%%%%%
-<<<<<<< HEAD
-<<<<<<< HEAD
-            for (NodeSimple& node : mesh.NodesTotal(displ))
-=======
-            int numUnconstrainedDofs = dofInfo.numIndependentDofs[displ];
-=======
->>>>>>> Merge current PDE reviewed
-                for (DofNode& node : mesh.NodesTotal(displ))
->>>>>>> Rename Nodes to DofNode and CoordinateNode
-                {
-                    int dofNumber = node.GetDofNumber(0);
-                    node.SetValue(0, solution[displ][dofNumber]);
-                }
+            for (DofNode& node : mesh.NodesTotal(displ))
+            {
+                int dofNumber = node.GetDofNumber(0);
+                node.SetValue(0, solution[displ][dofNumber]);
+            }
 
             // Calculate new residual %%%%%%%%%%%
             gradient = assembler.BuildVector(momentumBalanceCells, {displ}, MomentumGradientF);

--- a/applications/integrationtests/mechanics/CreepLaw.cpp
+++ b/applications/integrationtests/mechanics/CreepLaw.cpp
@@ -327,15 +327,18 @@ BOOST_AUTO_TEST_CASE(History_Data)
 
             // Merge dof values %%%%%%%%%%%%%%%%%
 <<<<<<< HEAD
+<<<<<<< HEAD
             for (NodeSimple& node : mesh.NodesTotal(displ))
 =======
             int numUnconstrainedDofs = dofInfo.numIndependentDofs[displ];
-            for (DofNode& node : mesh.NodesTotal(displ))
+=======
+>>>>>>> Merge current PDE reviewed
+                for (DofNode& node : mesh.NodesTotal(displ))
 >>>>>>> Rename Nodes to DofNode and CoordinateNode
-            {
-                int dofNumber = node.GetDofNumber(0);
-                node.SetValue(0, solution[displ][dofNumber]);
-            }
+                {
+                    int dofNumber = node.GetDofNumber(0);
+                    node.SetValue(0, solution[displ][dofNumber]);
+                }
 
             // Calculate new residual %%%%%%%%%%%
             gradient = assembler.BuildVector(momentumBalanceCells, {displ}, MomentumGradientF);

--- a/applications/integrationtests/mechanics/CreepLaw.cpp
+++ b/applications/integrationtests/mechanics/CreepLaw.cpp
@@ -15,6 +15,7 @@
 #include "nuto/mechanics/integrationtypes/IntegrationTypeTensorProduct.h"
 #include "nuto/mechanics/interpolation/InterpolationTrussLinear.h"
 #include "nuto/mechanics/mesh/MeshFem.h"
+#include "nuto/mechanics/mesh/GeometryMeshFem.h"
 #include "nuto/mechanics/mesh/MeshFemDofConvert.h"
 #include "nuto/mechanics/mesh/UnitMeshFem.h"
 #include "nuto/mechanics/nodes/DofNode.h"
@@ -220,7 +221,8 @@ using namespace std::placeholders;
 BOOST_AUTO_TEST_CASE(History_Data)
 {
     // Create mesh %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    MeshFem mesh = UnitMeshFem::CreateLines(numElements);
+    GeometryMeshFem geoMesh = UnitMeshFem::CreateLines(numElements);
+    MeshFem mesh(geoMesh);
 
     DofType displ("displacements", 1);
     const auto& interpolation = mesh.CreateInterpolation(InterpolationTrussLinear());

--- a/applications/integrationtests/mechanics/PatchTest.cpp
+++ b/applications/integrationtests/mechanics/PatchTest.cpp
@@ -57,15 +57,15 @@ MeshFem QuadPatchTestMesh(GeometryMeshFem& geoMesh)
      *              (c) ttitsche :)
      */
     MeshFem mesh(geoMesh);
-    CoordinateNode& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
-    CoordinateNode& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(10, 0));
-    CoordinateNode& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(10, 10));
-    CoordinateNode& n3 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 10));
+    CoordinateNode& n0 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
+    CoordinateNode& n1 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(10, 0));
+    CoordinateNode& n2 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(10, 10));
+    CoordinateNode& n3 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(0, 10));
 
-    CoordinateNode& n4 = mesh.CoordinateNodes.Add(Eigen::Vector2d(2, 2));
-    CoordinateNode& n5 = mesh.CoordinateNodes.Add(Eigen::Vector2d(8, 3));
-    CoordinateNode& n6 = mesh.CoordinateNodes.Add(Eigen::Vector2d(8, 7));
-    CoordinateNode& n7 = mesh.CoordinateNodes.Add(Eigen::Vector2d(4, 7));
+    CoordinateNode& n4 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(2, 2));
+    CoordinateNode& n5 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(8, 3));
+    CoordinateNode& n6 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(8, 7));
+    CoordinateNode& n7 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(4, 7));
 
     const InterpolationSimple& interpolation = mesh.CreateInterpolation(InterpolationQuadLinear());
 

--- a/applications/integrationtests/mechanics/PatchTest.cpp
+++ b/applications/integrationtests/mechanics/PatchTest.cpp
@@ -56,15 +56,15 @@ MeshFem QuadPatchTestMesh()
      *              (c) ttitsche :)
      */
     MeshFem mesh;
-    NodeCoordinates& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
-    NodeCoordinates& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(10, 0));
-    NodeCoordinates& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(10, 10));
-    NodeCoordinates& n3 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 10));
+    CoordinateNode& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
+    CoordinateNode& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(10, 0));
+    CoordinateNode& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(10, 10));
+    CoordinateNode& n3 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 10));
 
-    NodeCoordinates& n4 = mesh.CoordinateNodes.Add(Eigen::Vector2d(2, 2));
-    NodeCoordinates& n5 = mesh.CoordinateNodes.Add(Eigen::Vector2d(8, 3));
-    NodeCoordinates& n6 = mesh.CoordinateNodes.Add(Eigen::Vector2d(8, 7));
-    NodeCoordinates& n7 = mesh.CoordinateNodes.Add(Eigen::Vector2d(4, 7));
+    CoordinateNode& n4 = mesh.CoordinateNodes.Add(Eigen::Vector2d(2, 2));
+    CoordinateNode& n5 = mesh.CoordinateNodes.Add(Eigen::Vector2d(8, 3));
+    CoordinateNode& n6 = mesh.CoordinateNodes.Add(Eigen::Vector2d(8, 7));
+    CoordinateNode& n7 = mesh.CoordinateNodes.Add(Eigen::Vector2d(4, 7));
 
     const InterpolationSimple& interpolation = mesh.CreateInterpolation(InterpolationQuadLinear());
 
@@ -81,8 +81,8 @@ Constraint::Constraints DefineConstraints(MeshFem* rMesh, DofType dof)
 {
     Constraint::Constraints constraints;
 
-    Group<NodeSimple> nodesConstrainedInX = rMesh->NodesAtAxis(eDirection::X, dof);
-    Group<NodeSimple> nodesConstrainedInY = Group<NodeSimple>(rMesh->NodeAtCoordinate(Eigen::Vector2d(0, 0), dof));
+    Group<DofNode> nodesConstrainedInX = rMesh->NodesAtAxis(eDirection::X, dof);
+    Group<DofNode> nodesConstrainedInY = Group<DofNode>(rMesh->NodeAtCoordinate(Eigen::Vector2d(0, 0), dof));
 
     constraints.Add(dof, Constraint::Component(nodesConstrainedInX, {eDirection::X}));
     constraints.Add(dof, Constraint::Component(nodesConstrainedInY, {eDirection::Y}));
@@ -130,13 +130,13 @@ BOOST_AUTO_TEST_CASE(PatchTestForce)
     const InterpolationSimple& interpolationBc = mesh.CreateInterpolation(InterpolationTrussLinear());
 
     // extract existing nodes
-    Group<NodeCoordinates> boundaryCoordNodes = mesh.NodesAtAxis(eDirection::X, 10);
-    NodeCoordinates& nc1 = *boundaryCoordNodes.begin();
-    NodeCoordinates& nc2 = *(boundaryCoordNodes.begin() + 1);
+    Group<CoordinateNode> boundaryCoordNodes = mesh.NodesAtAxis(eDirection::X, 10);
+    CoordinateNode& nc1 = *boundaryCoordNodes.begin();
+    CoordinateNode& nc2 = *(boundaryCoordNodes.begin() + 1);
 
-    Group<NodeSimple> boundaryDisplNodes = mesh.NodesAtAxis(eDirection::X, displ, 10);
-    NodeSimple& nd1 = *boundaryDisplNodes.begin();
-    NodeSimple& nd2 = *(boundaryDisplNodes.begin() + 1);
+    Group<DofNode> boundaryDisplNodes = mesh.NodesAtAxis(eDirection::X, displ, 10);
+    DofNode& nd1 = *boundaryDisplNodes.begin();
+    DofNode& nd2 = *(boundaryDisplNodes.begin() + 1);
 
     // add the boundary element
     ElementCollectionFem& boundaryElement = mesh.Elements.Add({{{nc1, nc2}, interpolationBc}});
@@ -191,10 +191,10 @@ BOOST_AUTO_TEST_CASE(PatchTestForce)
         return Eigen::Vector2d(pressureBC[0] / E * coord[0], -nu * pressureBC[0] / E * coord[1]);
     };
 
-    for (NodeCoordinates& node : mesh.NodesTotal())
+    for (CoordinateNode& node : mesh.NodesTotal())
     {
         Eigen::VectorXd coord = node.GetValues();
-        NodeSimple& displNode = mesh.NodeAtCoordinate(coord, displ);
+        DofNode& displNode = mesh.NodeAtCoordinate(coord, displ);
 
         Eigen::VectorXd analyticSolution = analyticDisplacementField(coord);
 
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(PatchTestDispl)
     AddDofInterpolation(&mesh, displ, interpolation);
 
     auto constraints = DefineConstraints(&mesh, displ); // fixed boundary conditions
-    Group<NodeSimple> rightBoundary = mesh.NodesAtAxis(eDirection::X, displ, 10);
+    Group<DofNode> rightBoundary = mesh.NodesAtAxis(eDirection::X, displ, 10);
     const double boundaryDisplacement = 1.;
     constraints.Add(displ, Constraint::Component(rightBoundary, {eDirection::X}, boundaryDisplacement));
 

--- a/applications/integrationtests/mechanics/PatchTest.cpp
+++ b/applications/integrationtests/mechanics/PatchTest.cpp
@@ -56,15 +56,15 @@ MeshFem QuadPatchTestMesh()
      *              (c) ttitsche :)
      */
     MeshFem mesh;
-    NodeSimple& n0 = mesh.Nodes.Add(Eigen::Vector2d(0, 0));
-    NodeSimple& n1 = mesh.Nodes.Add(Eigen::Vector2d(10, 0));
-    NodeSimple& n2 = mesh.Nodes.Add(Eigen::Vector2d(10, 10));
-    NodeSimple& n3 = mesh.Nodes.Add(Eigen::Vector2d(0, 10));
+    NodeCoordinates& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
+    NodeCoordinates& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(10, 0));
+    NodeCoordinates& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(10, 10));
+    NodeCoordinates& n3 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 10));
 
-    NodeSimple& n4 = mesh.Nodes.Add(Eigen::Vector2d(2, 2));
-    NodeSimple& n5 = mesh.Nodes.Add(Eigen::Vector2d(8, 3));
-    NodeSimple& n6 = mesh.Nodes.Add(Eigen::Vector2d(8, 7));
-    NodeSimple& n7 = mesh.Nodes.Add(Eigen::Vector2d(4, 7));
+    NodeCoordinates& n4 = mesh.CoordinateNodes.Add(Eigen::Vector2d(2, 2));
+    NodeCoordinates& n5 = mesh.CoordinateNodes.Add(Eigen::Vector2d(8, 3));
+    NodeCoordinates& n6 = mesh.CoordinateNodes.Add(Eigen::Vector2d(8, 7));
+    NodeCoordinates& n7 = mesh.CoordinateNodes.Add(Eigen::Vector2d(4, 7));
 
     const InterpolationSimple& interpolation = mesh.CreateInterpolation(InterpolationQuadLinear());
 
@@ -130,9 +130,9 @@ BOOST_AUTO_TEST_CASE(PatchTestForce)
     const InterpolationSimple& interpolationBc = mesh.CreateInterpolation(InterpolationTrussLinear());
 
     // extract existing nodes
-    Group<NodeSimple> boundaryCoordNodes = mesh.NodesAtAxis(eDirection::X, 10);
-    NodeSimple& nc1 = *boundaryCoordNodes.begin();
-    NodeSimple& nc2 = *(boundaryCoordNodes.begin() + 1);
+    Group<NodeCoordinates> boundaryCoordNodes = mesh.NodesAtAxis(eDirection::X, 10);
+    NodeCoordinates& nc1 = *boundaryCoordNodes.begin();
+    NodeCoordinates& nc2 = *(boundaryCoordNodes.begin() + 1);
 
     Group<NodeSimple> boundaryDisplNodes = mesh.NodesAtAxis(eDirection::X, displ, 10);
     NodeSimple& nd1 = *boundaryDisplNodes.begin();
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(PatchTestForce)
         return Eigen::Vector2d(pressureBC[0] / E * coord[0], -nu * pressureBC[0] / E * coord[1]);
     };
 
-    for (NodeSimple& node : mesh.NodesTotal())
+    for (NodeCoordinates& node : mesh.NodesTotal())
     {
         Eigen::VectorXd coord = node.GetValues();
         NodeSimple& displNode = mesh.NodeAtCoordinate(coord, displ);

--- a/applications/integrationtests/mechanics/PatchTest.cpp
+++ b/applications/integrationtests/mechanics/PatchTest.cpp
@@ -163,7 +163,8 @@ BOOST_AUTO_TEST_CASE(PatchTestForce)
     DofVector<double> solution = Solve(hessian, -1.0 * gradient, constraints, {displ});
 
     // Merge dof values %%%%%%%%%%%%%%%%%
-    for (NodeSimple& node : mesh.NodesTotal(displ))
+
+    for (DofNode& node : mesh.NodesTotal(displ))
     {
         int dofNumber = node.GetDofNumber(0);
         node.SetValue(0, solution[displ][dofNumber]);

--- a/applications/integrationtests/mechanics/PatchTest.cpp
+++ b/applications/integrationtests/mechanics/PatchTest.cpp
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(PatchTestForce)
     const InterpolationSimple& interpolationBc = mesh.CreateInterpolation(InterpolationTrussLinear());
 
     // extract existing nodes
-    Group<CoordinateNode> boundaryCoordNodes = mesh.NodesAtAxis(eDirection::X, 10);
+    Group<CoordinateNode> boundaryCoordNodes = geoMesh.NodesAtAxis(eDirection::X, 10);
     CoordinateNode& nc1 = *boundaryCoordNodes.begin();
     CoordinateNode& nc2 = *(boundaryCoordNodes.begin() + 1);
 
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(PatchTestForce)
         return Eigen::Vector2d(pressureBC[0] / E * coord[0], -nu * pressureBC[0] / E * coord[1]);
     };
 
-    for (CoordinateNode& node : mesh.NodesTotal())
+    for (CoordinateNode& node : geoMesh.NodesTotal())
     {
         Eigen::VectorXd coord = node.GetCoordinates();
         DofNode& displNode = mesh.NodeAtCoordinate(coord, displ);
@@ -322,7 +322,7 @@ BOOST_AUTO_TEST_CASE(PatchTestDispl)
     // ************************************************************************
     auto analyticDisplacementField = [=](Eigen::Vector2d coord) { return Eigen::Vector2d(coord[0] * 0.1, 0); };
 
-    for (auto& node : mesh.NodesTotal())
+    for (auto& node : geoMesh.NodesTotal())
     {
         auto coord = node.GetCoordinates();
         auto& displNode = mesh.NodeAtCoordinate(coord, displ);

--- a/applications/integrationtests/mechanics/PatchTest.cpp
+++ b/applications/integrationtests/mechanics/PatchTest.cpp
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(PatchTestForce)
 
     for (CoordinateNode& node : mesh.NodesTotal())
     {
-        Eigen::VectorXd coord = node.GetValues();
+        Eigen::VectorXd coord = node.GetCoordinates();
         DofNode& displNode = mesh.NodeAtCoordinate(coord, displ);
 
         Eigen::VectorXd analyticSolution = analyticDisplacementField(coord);
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE(PatchTestDispl)
 
     for (auto& node : mesh.NodesTotal())
     {
-        auto coord = node.GetValues();
+        auto coord = node.GetCoordinates();
         auto& displNode = mesh.NodeAtCoordinate(coord, displ);
 
         auto analyticSolution = analyticDisplacementField(coord);

--- a/applications/integrationtests/mechanics/PatchTest.cpp
+++ b/applications/integrationtests/mechanics/PatchTest.cpp
@@ -10,6 +10,7 @@
 #include "nuto/mechanics/dofs/DofNumbering.h"
 
 #include "nuto/mechanics/mesh/MeshFem.h"
+#include "nuto/mechanics/mesh/GeometryMeshFem.h"
 #include "nuto/mechanics/mesh/MeshFemDofConvert.h"
 
 #include "nuto/mechanics/integrationtypes/IntegrationTypeTensorProduct.h"
@@ -55,7 +56,8 @@ MeshFem QuadPatchTestMesh()
      *   ///
      *              (c) ttitsche :)
      */
-    MeshFem mesh;
+    GeometryMeshFem geoMesh;
+    MeshFem mesh(geoMesh);
     CoordinateNode& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
     CoordinateNode& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(10, 0));
     CoordinateNode& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(10, 10));

--- a/applications/integrationtests/mechanics/QuasistaticProblem1D.cpp
+++ b/applications/integrationtests/mechanics/QuasistaticProblem1D.cpp
@@ -10,6 +10,7 @@
 #include "nuto/mechanics/integrationtypes/IntegrationTypeTensorProduct.h"
 #include "nuto/mechanics/constraints/ConstraintCompanion.h"
 #include "nuto/mechanics/mesh/UnitMeshFem.h"
+#include "nuto/mechanics/mesh/GeometryMeshFem.h"
 #include "nuto/mechanics/mesh/MeshFemDofConvert.h"
 #include "nuto/mechanics/tools/CellStorage.h"
 #include "nuto/mechanics/tools/QuasistaticSolver.h"
@@ -25,7 +26,8 @@ class LocalDamageTruss
 {
 public:
     LocalDamageTruss(int numElements, Material::Softening m)
-        : mMesh(UnitMeshFem::CreateLines(numElements))
+        : mGeoMesh(UnitMeshFem::CreateLines(numElements))
+        , mMesh(mGeoMesh)
         , mDof("Dispacement", 1)
         , mLaw(m)
         , mMomentumBalance(mDof, mLaw)
@@ -87,6 +89,7 @@ public:
     }
 
 private:
+    GeometryMeshFem mGeoMesh;
     MeshFem mMesh;
 
     DofType mDof;

--- a/applications/integrationtests/mechanics/StructuralGradientDamage.cpp
+++ b/applications/integrationtests/mechanics/StructuralGradientDamage.cpp
@@ -180,12 +180,12 @@ BOOST_AUTO_TEST_CASE(Integrand2D)
     auto& leftElementsGeo = gmsh.GetPhysicalGroup("left");
 
     Group<ElementCollectionFem> matrixElements;
-    for (auto cElm : matrixElementsGeo)
+    for (auto& cElm : matrixElementsGeo)
     {
         matrixElements.Add(mesh.Elements.Add(ElementCollectionFem(cElm)));
     }
     Group<ElementCollectionFem> leftElements;
-    for (auto cElm : leftElementsGeo)
+    for (auto& cElm : leftElementsGeo)
     {
         leftElements.Add(mesh.Elements.Add(ElementCollectionFem(cElm)));
     }

--- a/applications/integrationtests/mechanics/StructuralGradientDamage.cpp
+++ b/applications/integrationtests/mechanics/StructuralGradientDamage.cpp
@@ -44,8 +44,10 @@ BOOST_AUTO_TEST_CASE(Integrand)
     Gdm gdm(d, eeq, material);
 
     /* mesh, interpolations, constraints */
-    MeshFem mesh = UnitMeshFem::Transform(UnitMeshFem::CreateLines(80),
-                                          [&](Eigen::VectorXd x) { return Eigen::VectorXd::Constant(1, x[0] * L); });
+    GeometryMeshFem geoMesh = UnitMeshFem::Transform(
+            UnitMeshFem::CreateLines(80), [&](Eigen::VectorXd x) { return Eigen::VectorXd::Constant(1, x[0] * L); });
+
+    MeshFem mesh(geoMesh);
 
     InterpolationTrussLobatto interpolationD(2);
     AddDofInterpolation(&mesh, d, interpolationD);
@@ -172,9 +174,22 @@ BOOST_AUTO_TEST_CASE(Integrand2D)
 
     MeshGmsh gmsh(meshFile);
 
-    auto& mesh = gmsh.GetMeshFEM();
-    auto& matrixElements = gmsh.GetPhysicalGroup("matrix");
-    auto& leftElements = gmsh.GetPhysicalGroup("left");
+    auto& geoMesh = gmsh.GetMeshFEM();
+    MeshFem mesh(geoMesh);
+    auto& matrixElementsGeo = gmsh.GetPhysicalGroup("matrix");
+    auto& leftElementsGeo = gmsh.GetPhysicalGroup("left");
+
+    Group<ElementCollectionFem> matrixElements;
+    for (auto cElm : matrixElementsGeo)
+    {
+        matrixElements.Add(mesh.Elements.Add(ElementCollectionFem(cElm)));
+    }
+    Group<ElementCollectionFem> leftElements;
+    for (auto cElm : leftElementsGeo)
+    {
+        leftElements.Add(mesh.Elements.Add(ElementCollectionFem(cElm)));
+    }
+
     AddDofInterpolation(&mesh, d, matrixElements);
     AddDofInterpolation(&mesh, d, leftElements);
     AddDofInterpolation(&mesh, eeq, matrixElements);

--- a/applications/integrationtests/mechanics/VibrationalModes1D.cpp
+++ b/applications/integrationtests/mechanics/VibrationalModes1D.cpp
@@ -8,6 +8,7 @@
 #include "nuto/mechanics/integrationtypes/IntegrationTypeTensorProduct.h"
 #include "nuto/mechanics/constraints/Constraints.h"
 #include "nuto/mechanics/mesh/UnitMeshFem.h"
+#include "nuto/mechanics/mesh/GeometryMeshFem.h"
 #include "nuto/mechanics/mesh/MeshFemDofConvert.h"
 #include "nuto/mechanics/tools/CellStorage.h"
 
@@ -28,7 +29,8 @@ class VibratingTruss
 {
 public:
     VibratingTruss(int numElements, int order)
-        : mMesh(UnitMeshFem::CreateLines(numElements))
+        : mGeoMesh(UnitMeshFem::CreateLines(numElements))
+        , mMesh(mGeoMesh)
         , mOrder(order)
         , mDof("Dispacement", 1)
         , mLaw(Steel::E, Steel::nu)
@@ -66,6 +68,7 @@ public:
     }
 
 private:
+    GeometryMeshFem mGeoMesh;
     MeshFem mMesh;
     int mOrder;
 

--- a/applications/integrationtests/visualize/MeshFunction.cpp
+++ b/applications/integrationtests/visualize/MeshFunction.cpp
@@ -1,6 +1,8 @@
 #include <cmath>
 #include <boost/ptr_container/ptr_vector.hpp>
 #include "nuto/mechanics/mesh/UnitMeshFem.h"
+#include "nuto/mechanics/mesh/GeometryMeshFem.h"
+#include "nuto/mechanics/mesh/MeshFem.h"
 #include "nuto/mechanics/cell/Cell.h"
 #include "nuto/mechanics/integrationtypes/IntegrationTypeTensorProduct.h"
 #include "nuto/visualize/AverageHandler.h"
@@ -16,7 +18,8 @@ using namespace NuTo;
 int main()
 {
     auto meshTmp = UnitMeshFem::CreateQuads(50, 50);
-    auto mesh = UnitMeshFem::Transform(std::move(meshTmp), [](Eigen::VectorXd coords) { return 2 * pi() * coords; });
+    auto geoMesh = UnitMeshFem::Transform(std::move(meshTmp), [](Eigen::VectorXd coords) { return 2 * pi() * coords; });
+    MeshFem mesh(geoMesh);
     boost::ptr_vector<CellInterface> cells;
     IntegrationTypeTensorProduct<2> integrationType(2, eIntegrationMethod::GAUSS);
     int cellId = 0;

--- a/nuto/mechanics/CMakeLists.txt
+++ b/nuto/mechanics/CMakeLists.txt
@@ -4,6 +4,7 @@ add_sources(cell/SimpleAssembler.cpp
     dofs/DofNumbering.cpp
 
     mesh/MeshFem.cpp
+    mesh/GeometryMeshFem.cpp
     mesh/MeshFemDofConvert.cpp
     mesh/MeshGmsh.cpp
     mesh/UnitMeshFem.cpp

--- a/nuto/mechanics/cell/Cell.h
+++ b/nuto/mechanics/cell/Cell.h
@@ -50,7 +50,7 @@ public:
         for (int iIP = 0; iIP < mIntegrationType.GetNumIntegrationPoints(); ++iIP)
         {
             auto ipCoords = mIntegrationType.GetLocalIntegrationPointCoordinates(iIP);
-            Jacobian jacobian(mElements.CoordinateElement().ExtractNodeValues(),
+            Jacobian jacobian(mElements.CoordinateElement().ExtractCoordinates(),
                               mElements.CoordinateElement().GetDerivativeShapeFunctions(ipCoords));
             CellIpData cellipData(cellData, jacobian, ipCoords, iIP);
             f(cellipData);
@@ -84,7 +84,7 @@ public:
         for (int iIP = 0; iIP < mIntegrationType.GetNumIntegrationPoints(); ++iIP)
         {
             auto ipCoords = mIntegrationType.GetLocalIntegrationPointCoordinates(iIP);
-            Jacobian jacobian(mElements.CoordinateElement().ExtractNodeValues(),
+            Jacobian jacobian(mElements.CoordinateElement().ExtractCoordinates(),
                               mElements.CoordinateElement().GetDerivativeShapeFunctions(ipCoords));
             CellIpData cellipData(cellData, jacobian, ipCoords, iIP);
             result.push_back(f(cellipData));
@@ -110,7 +110,7 @@ private:
         {
             auto ipCoords = mIntegrationType.GetLocalIntegrationPointCoordinates(iIP);
             auto ipWeight = mIntegrationType.GetIntegrationPointWeight(iIP);
-            Jacobian jacobian(mElements.CoordinateElement().ExtractNodeValues(),
+            Jacobian jacobian(mElements.CoordinateElement().ExtractCoordinates(),
                               mElements.CoordinateElement().GetDerivativeShapeFunctions(ipCoords));
             CellIpData cellipData(cellData, jacobian, ipCoords, iIP);
             result += f(cellipData) * jacobian.Det() * ipWeight;

--- a/nuto/mechanics/cell/CellData.h
+++ b/nuto/mechanics/cell/CellData.h
@@ -27,7 +27,7 @@ public:
 
     Eigen::VectorXd GetCoordinates() const
     {
-        return mElements.CoordinateElement().ExtractNodeValues();
+        return mElements.CoordinateElement().ExtractCoordinates();
     }
 
     const Eigen::VectorXd& GetNodeValues(DofType dofType, int instance = 0) const

--- a/nuto/mechanics/constraints/ConstraintCompanion.cpp
+++ b/nuto/mechanics/constraints/ConstraintCompanion.cpp
@@ -1,6 +1,6 @@
 #include "nuto/base/Exception.h"
 #include "nuto/mechanics/constraints/ConstraintCompanion.h"
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 #include "nuto/mechanics/constraints/Equation.h"
 
 
@@ -18,13 +18,13 @@ RhsFunction RhsRamp(double timeEnd, double valueEnd)
 }
 
 
-std::vector<Equation> Component(const NodeSimple& node, std::vector<eDirection> directions, double value)
+std::vector<Equation> Component(const DofNode& node, std::vector<eDirection> directions, double value)
 {
     return Component(node, directions, RhsConstant(value));
 }
 
 
-std::vector<Equation> Component(const NodeSimple& node, std::vector<eDirection> directions, RhsFunction rhs)
+std::vector<Equation> Component(const DofNode& node, std::vector<eDirection> directions, RhsFunction rhs)
 {
     std::vector<Equation> eqs;
     for (auto direction : directions)
@@ -36,13 +36,13 @@ std::vector<Equation> Component(const NodeSimple& node, std::vector<eDirection> 
 }
 
 
-std::vector<Equation> Component(const Group<NodeSimple>& nodes, std::vector<eDirection> directions, double value)
+std::vector<Equation> Component(const Group<DofNode>& nodes, std::vector<eDirection> directions, double value)
 {
     return Component(nodes, directions, RhsConstant(value));
 }
 
 
-std::vector<Equation> Component(const Group<NodeSimple>& nodes, std::vector<eDirection> directions, RhsFunction rhs)
+std::vector<Equation> Component(const Group<DofNode>& nodes, std::vector<eDirection> directions, RhsFunction rhs)
 {
     std::vector<Equation> eqs;
     for (const auto& node : nodes)
@@ -54,7 +54,7 @@ std::vector<Equation> Component(const Group<NodeSimple>& nodes, std::vector<eDir
 }
 
 
-Equation Direction(const NodeSimple& node, Eigen::VectorXd direction, RhsFunction rhs)
+Equation Direction(const DofNode& node, Eigen::VectorXd direction, RhsFunction rhs)
 {
 
     int maxComponentIndex = -1;
@@ -79,12 +79,12 @@ Equation Direction(const NodeSimple& node, Eigen::VectorXd direction, RhsFunctio
     return e;
 }
 
-Equation Direction(const NodeSimple& node, Eigen::VectorXd direction, double value)
+Equation Direction(const DofNode& node, Eigen::VectorXd direction, double value)
 {
     return Direction(node, direction, RhsConstant(value));
 }
 
-std::vector<Equation> Direction(const Group<NodeSimple>& nodes, Eigen::VectorXd direction, RhsFunction rhs)
+std::vector<Equation> Direction(const Group<DofNode>& nodes, Eigen::VectorXd direction, RhsFunction rhs)
 {
     std::vector<Equation> eqs;
     for (auto& node : nodes)
@@ -92,24 +92,24 @@ std::vector<Equation> Direction(const Group<NodeSimple>& nodes, Eigen::VectorXd 
     return eqs;
 }
 
-std::vector<Equation> Direction(const Group<NodeSimple>& nodes, Eigen::VectorXd direction, double value)
+std::vector<Equation> Direction(const Group<DofNode>& nodes, Eigen::VectorXd direction, double value)
 {
     return Direction(nodes, direction, RhsConstant(value));
 }
 
-Equation Value(const NodeSimple& node, double value)
+Equation Value(const DofNode& node, double value)
 {
     return Value(node, RhsConstant(value));
 }
 
-Equation Value(const NodeSimple& node, RhsFunction rhs)
+Equation Value(const DofNode& node, RhsFunction rhs)
 {
     if (node.GetNumValues() != 1)
         throw Exception(__PRETTY_FUNCTION__, "This function is meant to be used with single value nodes only");
     return Component(node, {eDirection::X}, rhs)[0];
 }
 
-std::vector<Equation> Value(const Group<NodeSimple>& nodes, double value)
+std::vector<Equation> Value(const Group<DofNode>& nodes, double value)
 {
     std::vector<Equation> eqs;
     for (auto& node : nodes)
@@ -117,7 +117,7 @@ std::vector<Equation> Value(const Group<NodeSimple>& nodes, double value)
     return eqs;
 }
 
-std::vector<Equation> Value(const Group<NodeSimple>& nodes, RhsFunction rhs)
+std::vector<Equation> Value(const Group<DofNode>& nodes, RhsFunction rhs)
 {
     std::vector<Equation> eqs;
     for (auto& node : nodes)

--- a/nuto/mechanics/constraints/ConstraintCompanion.h
+++ b/nuto/mechanics/constraints/ConstraintCompanion.h
@@ -4,7 +4,7 @@
 #include "nuto/mechanics/constraints/Constraints.h"
 #include "nuto/mechanics/constraints/Equation.h"
 #include "nuto/mechanics/DirectionEnum.h"
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 
 namespace NuTo
 {
@@ -32,28 +32,28 @@ inline RhsFunction RhsConstant(double constantValue)
 //! @param directions vector of directions (X, Y, Z)
 //! @param value constant value
 //! @return vector of constraint equations
-std::vector<Equation> Component(const NodeSimple& node, std::vector<eDirection> directions, double value = 0.0);
+std::vector<Equation> Component(const DofNode& node, std::vector<eDirection> directions, double value = 0.0);
 
 //! @brief constraints components of vector valued nodes in X and/or Y and/or Z
 //! @param nodes group of nodes
 //! @param directions vector of directions (X, Y, Z)
 //! @param value constant value
 //! @return vector of constraint equations
-std::vector<Equation> Component(const Group<NodeSimple>& nodes, std::vector<eDirection> directions, double value = 0.0);
+std::vector<Equation> Component(const Group<DofNode>& nodes, std::vector<eDirection> directions, double value = 0.0);
 
 //! @brief constraints components of vector valued nodes in X and/or Y and/or Z
 //! @param node node reference
 //! @param directions vector of directions (X, Y, Z)
 //! @param rhs time dependent constraint function (double time) --> double
 //! @return vector of constraint equations
-std::vector<Equation> Component(const NodeSimple& node, std::vector<eDirection> directions, RhsFunction rhs);
+std::vector<Equation> Component(const DofNode& node, std::vector<eDirection> directions, RhsFunction rhs);
 
 //! @brief constraints components of vector valued nodes in X and/or Y and/or Z
 //! @param nodes group of nodes
 //! @param directions vector of directions (X, Y, Z)
 //! @param rhs time dependent constraint function (double time) --> double
 //! @return vector of constraint equations
-std::vector<Equation> Component(const Group<NodeSimple>& nodes, std::vector<eDirection> directions, RhsFunction rhs);
+std::vector<Equation> Component(const Group<DofNode>& nodes, std::vector<eDirection> directions, RhsFunction rhs);
 
 
 //! @brief creates a constraint equation for constraints that are not axes aligned
@@ -61,52 +61,52 @@ std::vector<Equation> Component(const Group<NodeSimple>& nodes, std::vector<eDir
 //! @param direction directions (X, Y, Z)
 //! @param rhs time dependent constraint function (double time) --> double
 //! @return constraint equation
-Equation Direction(const NodeSimple& node, Eigen::VectorXd direction, RhsFunction rhs);
+Equation Direction(const DofNode& node, Eigen::VectorXd direction, RhsFunction rhs);
 
 //! @brief creates a constraint equation for constraints that are not axes aligned
 //! @param node node reference
 //! @param direction directions (X, Y, Z)
 //! @param value constant value
 //! @return constraint equation
-Equation Direction(const NodeSimple& node, Eigen::VectorXd direction, double value = 0.0);
+Equation Direction(const DofNode& node, Eigen::VectorXd direction, double value = 0.0);
 
 //! @brief creates multiple constraint equations for constraints that are not axes aligned
 //! @param nodes group of nodes
 //! @param direction directions (X, Y, Z)
 //! @param rhs time dependent constraint function (double time) --> double
 //! @return vector of constraint equations
-std::vector<Equation> Direction(const Group<NodeSimple>& nodes, Eigen::VectorXd direction, RhsFunction rhs);
+std::vector<Equation> Direction(const Group<DofNode>& nodes, Eigen::VectorXd direction, RhsFunction rhs);
 
 //! @brief creates multiple constraint equations for constraints that are not axes aligned
 //! @param nodes group of nodes
 //! @param direction directions (X, Y, Z)
 //! @param value constant value
 //! @return vector of constraint equations
-std::vector<Equation> Direction(const Group<NodeSimple>& nodes, Eigen::VectorXd direction, double value = 0.0);
+std::vector<Equation> Direction(const Group<DofNode>& nodes, Eigen::VectorXd direction, double value = 0.0);
 
 //! @brief Constraint single value node
 //! @param node node reference
 //! @param value constant value
 //! @return constraint equation
-Equation Value(const NodeSimple& node, double value = 0.0);
+Equation Value(const DofNode& node, double value = 0.0);
 
 //! @brief Constraint single value node
 //! @param node node reference
 //! @param rhs time dependent constraint function (double time) --> double
 //! @return constraint equation
-Equation Value(const NodeSimple& node, RhsFunction rhs);
+Equation Value(const DofNode& node, RhsFunction rhs);
 
 //! @brief Constraint group of single value nodes
 //! @param nodes group of nodes
 //! @param value constant value
 //! @return vector of constraint equations
-std::vector<Equation> Value(const Group<NodeSimple>& nodes, double value = 0.0);
+std::vector<Equation> Value(const Group<DofNode>& nodes, double value = 0.0);
 
 //! @brief Constraint group of single value nodes
 //! @param nodes group of nodes
 //! @param rhs time dependent constraint function (double time) --> double
 //! @return vector of constraint equations
-std::vector<Equation> Value(const Group<NodeSimple>& nodes, RhsFunction rhs);
+std::vector<Equation> Value(const Group<DofNode>& nodes, RhsFunction rhs);
 
 } /* Constraint */
 } /* NuTo */

--- a/nuto/mechanics/constraints/Constraints.cpp
+++ b/nuto/mechanics/constraints/Constraints.cpp
@@ -123,6 +123,7 @@ Eigen::SparseMatrix<double> Constraints::BuildUnitConstraintMatrix(DofType dof, 
             int globalDofNumber = term.GetConstrainedDofNumber();
             int independentDofNumber = reverseJKNumbering[globalDofNumber];
             assert(independentDofNumber < numIndependentDofs);
+
             if (globalDofNumber == -1 /* should be NodeSimple::NOT_SET */)
                 throw Exception(__PRETTY_FUNCTION__,
                                 "There is no dof numbering for a node in equation" + std::to_string(iEquation) + ".");

--- a/nuto/mechanics/constraints/Equation.h
+++ b/nuto/mechanics/constraints/Equation.h
@@ -16,7 +16,7 @@ public:
     //! @param dependentNode node reference
     //! @param dependentComponent component in the dof vector of the node
     //! @param rhs value for the constant rhs
-    Equation(const NodeSimple& dependentNode, int dependentComponent, RhsFunction rhs)
+    Equation(const DofNode& dependentNode, int dependentComponent, RhsFunction rhs)
         : mRhs(rhs)
         , mDependentTerm(dependentNode, dependentComponent, 1)
     {

--- a/nuto/mechanics/constraints/Term.h
+++ b/nuto/mechanics/constraints/Term.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "nuto/base/Exception.h"
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 
 namespace NuTo
 {
@@ -15,20 +15,20 @@ public:
     //! @param node node reference
     //! @param component component in the dof vector of the node, has to be smaller than node.GetNumValues()
     //! @param coefficient coefficient of the equation term
-    Term(const NodeSimple& node, int component, double coefficient)
+    Term(const DofNode& node, int component, double coefficient)
         : mNode(node)
         , mComponent(component)
         , mCoefficient(coefficient)
     {
         if (component >= node.GetNumValues())
-            throw Exception(__PRETTY_FUNCTION__, "Term construction failed. Node has " +
-                                                         std::to_string(node.GetNumValues()) +
-                                                         " components and you tried to constrain component " +
-                                                         std::to_string(component) + ".");
+            throw Exception(__PRETTY_FUNCTION__,
+                            "Term construction failed. Node has " + std::to_string(node.GetNumValues()) +
+                                    " components and you tried to constrain component " + std::to_string(component) +
+                                    ".");
     }
 
     //! @brief getter for mNode
-    const NodeSimple& GetNode() const
+    const DofNode& GetNode() const
     {
         return mNode;
     }
@@ -54,7 +54,7 @@ private:
     //! @brief node reference
     //! @remark `std::reference_wrapper` is used instead of a reference to
     //! make `Term` default CopyAssignable
-    std::reference_wrapper<const NodeSimple> mNode;
+    std::reference_wrapper<const DofNode> mNode;
 
     //! @brief component component in the dof vector of the node
     int mComponent;

--- a/nuto/mechanics/dofs/DofNumbering.cpp
+++ b/nuto/mechanics/dofs/DofNumbering.cpp
@@ -4,7 +4,7 @@ using namespace NuTo;
 
 //! @brief build dof numbering, starting at 0, for all `nodes` regardless of constraints
 //! @return total number of dofs in `nodes`
-int InitialUnconstrainedNumbering(const Group<NodeSimple>& nodes)
+int InitialUnconstrainedNumbering(const Group<DofNode>& nodes)
 {
     int dofNumber = 0;
     for (auto& node : nodes)
@@ -29,7 +29,7 @@ std::vector<int> GetStatusOfDofNumber(const Constraint::Constraints& constraints
     return dofStatus;
 }
 
-DofInfo DofNumbering::Build(const Group<NodeSimple>& dofNodes, DofType dof, const Constraint::Constraints& constraints)
+DofInfo DofNumbering::Build(const Group<DofNode>& dofNodes, DofType dof, const Constraint::Constraints& constraints)
 {
     for (int iEquation = 0; iEquation < constraints.GetNumEquations(dof); ++iEquation)
     {
@@ -57,7 +57,7 @@ DofInfo DofNumbering::Build(const Group<NodeSimple>& dofNodes, DofType dof, cons
     return dofInfo;
 }
 
-std::vector<int> DofNumbering::Get(const Group<NodeSimple>& dofNodes, int component)
+std::vector<int> DofNumbering::Get(const Group<DofNode>& dofNodes, int component)
 {
     std::vector<int> dofNumbers;
     dofNumbers.reserve(dofNodes.Size());

--- a/nuto/mechanics/dofs/DofNumbering.h
+++ b/nuto/mechanics/dofs/DofNumbering.h
@@ -4,7 +4,7 @@
 
 #include "nuto/mechanics/dofs/DofInfo.h"
 #include "nuto/mechanics/constraints/Constraints.h"
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 
 namespace NuTo
 {
@@ -14,10 +14,10 @@ namespace DofNumbering
 
 //! Builds the dof numbering for type `dof` for all the `dofNodes` and stores it at the `dofNodes`.
 //! @remark Numbering starts at 0 with all the dofs that are not constrained. Constrained dofs have the highest numbers
-DofInfo Build(const Group<NodeSimple>& dofNodes, DofType dof, const Constraint::Constraints& constraints);
+DofInfo Build(const Group<DofNode>& dofNodes, DofType dof, const Constraint::Constraints& constraints);
 
 //! Extracts the dof numbers from `dofNodes` for a given component (0 for scalar, x=0, y=1, z=2 for vector dofs)
-std::vector<int> Get(const Group<NodeSimple>& dofNodes, int component = 0);
+std::vector<int> Get(const Group<DofNode>& dofNodes, int component = 0);
 
 } /* DofNumbering */
 } /* NuTo */

--- a/nuto/mechanics/elements/CoordinateElementFem.h
+++ b/nuto/mechanics/elements/CoordinateElementFem.h
@@ -3,13 +3,13 @@
 #include <vector>
 #include "nuto/base/Exception.h"
 #include "nuto/mechanics/nodes/CoordinateNode.h"
-#include "nuto/mechanics/elements/ElementInterface.h"
+#include "nuto/mechanics/elements/CoordinateElementInterface.h"
 #include "nuto/mechanics/interpolation/InterpolationSimple.h"
 #include "nuto/mechanics/cell/Matrix.h"
 
 namespace NuTo
 {
-class CoordinateElementFem : public ElementInterface
+class CoordinateElementFem : public CoordinateElementInterface
 {
 public:
     CoordinateElementFem(std::vector<CoordinateNode*> nodes, const InterpolationSimple& interpolation)
@@ -30,11 +30,8 @@ public:
         assert(static_cast<int>(mNodes.size()) == interpolation.GetNumNodes());
     }
 
-    virtual Eigen::VectorXd ExtractNodeValues(int instance = 0) const override
+    virtual Eigen::VectorXd ExtractCoordinates() const override
     {
-        // Solve this later, by using type traits
-        assert(instance == 0 && "Coordinate nodes can have only 1 instance");
-
         const int dim = GetDofDimension();
         Eigen::VectorXd nodeValues(GetNumNodes() * dim);
         for (int i = 0; i < GetNumNodes(); ++i)
@@ -60,11 +57,6 @@ public:
     virtual int GetDofDimension() const override
     {
         return GetNode(0).GetNumValues();
-    }
-
-    Eigen::VectorXi GetDofNumbering() const override
-    {
-        throw Exception(__PRETTY_FUNCTION__, "Coordinate nodes have no dof numbering");
     }
 
     virtual int GetNumNodes() const override

--- a/nuto/mechanics/elements/CoordinateElementFem.h
+++ b/nuto/mechanics/elements/CoordinateElementFem.h
@@ -30,7 +30,7 @@ public:
         assert(static_cast<int>(mNodes.size()) == interpolation.GetNumNodes());
     }
 
-    virtual Eigen::VectorXd ExtractCoordinates() const override
+    Eigen::VectorXd ExtractCoordinates() const override
     {
         const int dim = GetDofDimension();
         Eigen::VectorXd nodeValues(GetNumNodes() * dim);
@@ -39,27 +39,27 @@ public:
         return nodeValues;
     }
 
-    virtual Eigen::MatrixXd GetNMatrix(NaturalCoords ipCoords) const override
+    Eigen::MatrixXd GetNMatrix(NaturalCoords ipCoords) const override
     {
         return Matrix::N(Interpolation().GetShapeFunctions(ipCoords), Interpolation().GetNumNodes(), GetDofDimension());
     }
 
-    virtual Eigen::VectorXd GetShapeFunctions(NaturalCoords ipCoords) const override
+    Eigen::VectorXd GetShapeFunctions(NaturalCoords ipCoords) const override
     {
         return Interpolation().GetShapeFunctions(ipCoords);
     }
 
-    virtual Eigen::MatrixXd GetDerivativeShapeFunctions(NaturalCoords ipCoords) const override
+    Eigen::MatrixXd GetDerivativeShapeFunctions(NaturalCoords ipCoords) const override
     {
         return Interpolation().GetDerivativeShapeFunctions(ipCoords);
     }
 
-    virtual int GetDofDimension() const override
+    int GetDofDimension() const override
     {
         return GetNode(0).GetNumValues();
     }
 
-    virtual int GetNumNodes() const override
+    int GetNumNodes() const override
     {
         return mNodes.size();
     }

--- a/nuto/mechanics/elements/CoordinateElementFem.h
+++ b/nuto/mechanics/elements/CoordinateElementFem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include "nuto/base/Exception.h"
 #include "nuto/mechanics/nodes/CoordinateNode.h"
 #include "nuto/mechanics/elements/ElementInterface.h"
 #include "nuto/mechanics/interpolation/InterpolationSimple.h"
@@ -20,7 +21,8 @@ public:
         assert(static_cast<int>(mNodes.size()) == interpolation.GetNumNodes());
     }
 
-    CoordinateElementFem(std::initializer_list<std::reference_wrapper<CoordinateNode>> nodes, const InterpolationSimple& interpolation)
+    CoordinateElementFem(std::initializer_list<std::reference_wrapper<CoordinateNode>> nodes,
+                         const InterpolationSimple& interpolation)
         : mNodes(nodes)
         , mInterpolation(interpolation)
         , mShape(interpolation.GetShape())
@@ -62,7 +64,7 @@ public:
 
     Eigen::VectorXi GetDofNumbering() const override
     {
-        assert(false && "Coordinate nodes have no dof numbering");
+        throw Exception(__PRETTY_FUNCTION__, "Coordinate nodes have no dof numbering");
     }
 
     virtual int GetNumNodes() const override

--- a/nuto/mechanics/elements/CoordinateElementFem.h
+++ b/nuto/mechanics/elements/CoordinateElementFem.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <vector>
+#include "nuto/mechanics/nodes/CoordinateNode.h"
+#include "nuto/mechanics/elements/ElementInterface.h"
+#include "nuto/mechanics/interpolation/InterpolationSimple.h"
+#include "nuto/mechanics/cell/Matrix.h"
+
+namespace NuTo
+{
+class CoordinateElementFem : public ElementInterface
+{
+public:
+    CoordinateElementFem(std::vector<CoordinateNode*> nodes, const InterpolationSimple& interpolation)
+        : mInterpolation(interpolation)
+        , mShape(interpolation.GetShape())
+    {
+        for (CoordinateNode* node : nodes)
+            mNodes.push_back(*node);
+        assert(static_cast<int>(mNodes.size()) == interpolation.GetNumNodes());
+    }
+
+    CoordinateElementFem(std::initializer_list<std::reference_wrapper<CoordinateNode>> nodes, const InterpolationSimple& interpolation)
+        : mNodes(nodes)
+        , mInterpolation(interpolation)
+        , mShape(interpolation.GetShape())
+    {
+        assert(static_cast<int>(mNodes.size()) == interpolation.GetNumNodes());
+    }
+
+    virtual Eigen::VectorXd ExtractNodeValues(int instance = 0) const override
+    {
+        // Solve this later, by using type traits
+        assert(instance == 0 && "Coordinate nodes can have only 1 instance");
+
+        const int dim = GetDofDimension();
+        Eigen::VectorXd nodeValues(GetNumNodes() * dim);
+        for (int i = 0; i < GetNumNodes(); ++i)
+            nodeValues.segment(dim * i, dim) = GetNode(i).GetCoordinates();
+        return nodeValues;
+    }
+
+    virtual Eigen::MatrixXd GetNMatrix(NaturalCoords ipCoords) const override
+    {
+        return Matrix::N(Interpolation().GetShapeFunctions(ipCoords), Interpolation().GetNumNodes(), GetDofDimension());
+    }
+
+    virtual Eigen::VectorXd GetShapeFunctions(NaturalCoords ipCoords) const override
+    {
+        return Interpolation().GetShapeFunctions(ipCoords);
+    }
+
+    virtual Eigen::MatrixXd GetDerivativeShapeFunctions(NaturalCoords ipCoords) const override
+    {
+        return Interpolation().GetDerivativeShapeFunctions(ipCoords);
+    }
+
+    virtual int GetDofDimension() const override
+    {
+        return GetNode(0).GetNumValues();
+    }
+
+    Eigen::VectorXi GetDofNumbering() const override
+    {
+        assert(false && "Coordinate nodes have no dof numbering");
+    }
+
+    virtual int GetNumNodes() const override
+    {
+        return mNodes.size();
+    }
+
+
+    const InterpolationSimple& Interpolation() const
+    {
+        return mInterpolation;
+    }
+
+    CoordinateNode& GetNode(int i)
+    {
+        assert(i < static_cast<int>(mNodes.size()));
+        return mNodes[i];
+    }
+
+
+    const CoordinateNode& GetNode(int i) const
+    {
+        assert(i < static_cast<int>(mNodes.size()));
+        return mNodes[i];
+    }
+
+    const Shape& GetShape() const
+    {
+        return mShape;
+    }
+
+private:
+    std::vector<std::reference_wrapper<CoordinateNode>> mNodes;
+    std::reference_wrapper<const InterpolationSimple> mInterpolation;
+    const Shape& mShape;
+};
+
+} /* NuTo */

--- a/nuto/mechanics/elements/CoordinateElementInterface.h
+++ b/nuto/mechanics/elements/CoordinateElementInterface.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <eigen3/Eigen/Core>
+#include "nuto/mechanics/interpolation/TypeDefs.h"
+#include "nuto/mechanics/elements/ElementInterface.h"
+
+namespace NuTo
+{
+
+class CoordinateElementInterface : public ElementInterface
+{
+public:
+    virtual ~CoordinateElementInterface() noexcept = default;
+
+    //! @brief extracts all node values of this element
+    //!
+    //! They are ordered in blocks belonging to a node, e.g:
+    //! coordinate Nodes in 3D:
+    //!   NodeValues: (x1,y1,z1, x2,y2,z2, ...)
+    virtual Eigen::VectorXd ExtractCoordinates() const = 0;
+};
+
+inline Eigen::VectorXd Interpolate(const CoordinateElementInterface& element, NaturalCoords ipCoords)
+{
+    return element.GetNMatrix(ipCoords) * element.ExtractCoordinates();
+}
+
+
+} /* NuTo */

--- a/nuto/mechanics/elements/DofElementFem.h
+++ b/nuto/mechanics/elements/DofElementFem.h
@@ -2,13 +2,13 @@
 
 #include <vector>
 #include "nuto/mechanics/nodes/DofNode.h"
-#include "nuto/mechanics/elements/ElementInterface.h"
+#include "nuto/mechanics/elements/DofElementInterface.h"
 #include "nuto/mechanics/interpolation/InterpolationSimple.h"
 #include "nuto/mechanics/cell/Matrix.h"
 
 namespace NuTo
 {
-class DofElementFem : public ElementInterface
+class DofElementFem : public DofElementInterface
 {
 public:
     DofElementFem(std::vector<DofNode*> nodes, const InterpolationSimple& interpolation)
@@ -20,7 +20,8 @@ public:
         assert(static_cast<int>(mNodes.size()) == interpolation.GetNumNodes());
     }
 
-    DofElementFem(std::initializer_list<std::reference_wrapper<DofNode>> nodes, const InterpolationSimple& interpolation)
+    DofElementFem(std::initializer_list<std::reference_wrapper<DofNode>> nodes,
+                  const InterpolationSimple& interpolation)
         : mNodes(nodes)
         , mInterpolation(interpolation)
         , mShape(interpolation.GetShape())

--- a/nuto/mechanics/elements/DofElementFem.h
+++ b/nuto/mechanics/elements/DofElementFem.h
@@ -29,7 +29,7 @@ public:
         assert(static_cast<int>(mNodes.size()) == interpolation.GetNumNodes());
     }
 
-    virtual Eigen::VectorXd ExtractNodeValues(int instance = 0) const override
+    Eigen::VectorXd ExtractNodeValues(int instance = 0) const override
     {
         const int dim = GetDofDimension();
         Eigen::VectorXd nodeValues(GetNumNodes() * dim);
@@ -38,22 +38,22 @@ public:
         return nodeValues;
     }
 
-    virtual Eigen::MatrixXd GetNMatrix(NaturalCoords ipCoords) const override
+    Eigen::MatrixXd GetNMatrix(NaturalCoords ipCoords) const override
     {
         return Matrix::N(Interpolation().GetShapeFunctions(ipCoords), Interpolation().GetNumNodes(), GetDofDimension());
     }
 
-    virtual Eigen::VectorXd GetShapeFunctions(NaturalCoords ipCoords) const override
+    Eigen::VectorXd GetShapeFunctions(NaturalCoords ipCoords) const override
     {
         return Interpolation().GetShapeFunctions(ipCoords);
     }
 
-    virtual Eigen::MatrixXd GetDerivativeShapeFunctions(NaturalCoords ipCoords) const override
+    Eigen::MatrixXd GetDerivativeShapeFunctions(NaturalCoords ipCoords) const override
     {
         return Interpolation().GetDerivativeShapeFunctions(ipCoords);
     }
 
-    virtual int GetDofDimension() const override
+    int GetDofDimension() const override
     {
         return GetNode(0).GetNumValues();
     }
@@ -73,7 +73,7 @@ public:
         return dofNumbering;
     }
 
-    virtual int GetNumNodes() const override
+    int GetNumNodes() const override
     {
         return mNodes.size();
     }

--- a/nuto/mechanics/elements/DofElementInterface.h
+++ b/nuto/mechanics/elements/DofElementInterface.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <eigen3/Eigen/Core>
+#include "nuto/mechanics/interpolation/TypeDefs.h"
+#include "nuto/mechanics/elements/ElementInterface.h"
+
+namespace NuTo
+{
+
+class DofElementInterface : public ElementInterface
+{
+public:
+    virtual ~DofElementInterface() noexcept = default;
+
+    //! @brief extracts all node values of this element
+    //!
+    //! They are ordered in blocks belonging to a node, e.g:
+    //! coordinate Nodes in 3D:
+    //!   NodeValues: (x1,y1,z1, x2,y2,z2, ...)
+    virtual Eigen::VectorXd ExtractNodeValues(int instance = 0) const = 0;
+
+    //! @brief extract the dof numbers from its nodes.
+    //! @remark They have to be in the same order as defined in ExtractNodeValues()
+    virtual Eigen::VectorXi GetDofNumbering() const = 0;
+};
+
+inline Eigen::VectorXd Interpolate(const DofElementInterface& element, NaturalCoords ipCoords)
+{
+    return element.GetNMatrix(ipCoords) * element.ExtractNodeValues();
+}
+
+
+} /* NuTo */

--- a/nuto/mechanics/elements/ElementCollection.h
+++ b/nuto/mechanics/elements/ElementCollection.h
@@ -124,7 +124,7 @@ public:
     static_assert(std::is_base_of<ElementInterface, DofElementFem>::value,
                   "TElement must be a descendant of ElementInterface");
 
-    ElementCollectionFem(CoordinateElementFem coordinateElement)
+    ElementCollectionFem(CoordinateElementFem& coordinateElement)
         : mCoordinateElement(coordinateElement)
         , mShape(coordinateElement.GetShape())
     {
@@ -189,7 +189,7 @@ public:
     }
 
 private:
-    CoordinateElementFem mCoordinateElement;
+    CoordinateElementFem& mCoordinateElement;
     DofContainer<DofElementFem> mDofElements;
     const Shape& mShape;
 };

--- a/nuto/mechanics/elements/ElementCollection.h
+++ b/nuto/mechanics/elements/ElementCollection.h
@@ -9,9 +9,9 @@ namespace NuTo
 {
 //! @brief interface for all the cell operations, simply forwarding the corresponding element interfaces
 //! @remark two benefits: a) avoids forwarding all the methods of ElementInterface for _both_ the
-//                           coordinate element and the dof elements.
-//                        b) allows storing elements (implementations of ElementInterface) by value
-//                           in the class ElementCollectionImpl.
+//!                           coordinate element and the dof elements.
+//!                        b) allows storing elements (implementations of ElementInterface) by value
+//!                           in the class ElementCollectionImpl.
 class ElementCollection
 {
 public:
@@ -23,11 +23,12 @@ public:
 
 //! @brief implementation of the interface ElementCollection for arbitrary element types that are derived from
 //! ElementInterface
-//! @tparam TElement element type stored by value
+//! @tparam TCoordinateElement coordinate element type stored by value
+//! @tparam TDofElement dof element type stored by value
 //! @remark This class stores elements by value. This is nice since it allows the copy/move operations, value
 //! semantics. Additionally, the compiler is free to eliminate all the copies (whenever that is the right thing to do).
 //! The access to the underlying elements is provided via const-reference. This reference is implicitly casted to the
-//! base class ElementInterface.
+//! base class Coordinate- or DofElementInterface.
 template <typename TCoordinateElement, typename TDofElement>
 class ElementCollectionImpl : public ElementCollection
 {
@@ -108,18 +109,12 @@ private:
     const Shape& mShape;
 };
 
-// using ElementCollectionFem = ElementCollectionImpl<NuTo::DofElementFem>;
-
 template <int TDimParameter>
 using ElementCollectionIga = ElementCollectionImpl<NuTo::ElementIga<TDimParameter>, NuTo::ElementIga<TDimParameter>>;
 
 
 //! @brief implementation of the interface ElementCollection for ElementFem (uses different element types for dofs and
 //! coordinates)
-//! @remark This class stores elements by value. This is nice since it allows the copy/move operations, value
-//! semantics. Additionally, the compiler is free to eliminate all the copies (whenever that is the right thing to do).
-//! The access to the underlying elements is provided via const-reference. This reference is implicitly casted to the
-//! base class ElementInterface.
 class ElementCollectionFem : public ElementCollection
 {
 public:
@@ -144,16 +139,16 @@ public:
     }
 
     //! @brief Getter for CoordinateElement
-    //! @return reference to TElement. This is implicitly casted to a reference ElementInterface when accessed via
-    //! ElementCollection
+    //! @return reference to a the CoordinateElementFem. This is implicitly casted to a reference
+    //! CoordinateElementInterface when accessed via ElementCollection
     const CoordinateElementFem& CoordinateElement() const override
     {
         return mCoordinateElement;
     }
 
     //! @brief nonconst Getter for CoordinateElement
-    //! @return reference to TElement. This is implicitly casted to a reference ElementInterface when accessed via
-    //! ElementCollection
+    //! @return reference to a the CoordinateElementFem. This is implicitly casted to a reference
+    //! CoordinateElementInterface when accessed via ElementCollection
     CoordinateElementFem& CoordinateElement()
     {
         return mCoordinateElement;
@@ -161,8 +156,8 @@ public:
 
     //! @brief Getter for DofElements
     //! @param dofType dof type
-    //! @return reference to TElement. This is implicitly casted to a reference ElementInterface when accessed via
-    //! ElementCollection
+    //! @return reference to a the DofElementFem. This is implicitly casted to a reference
+    //! DofElementInterface when accessed via ElementCollection
     const DofElementFem& DofElement(DofType dofType) const override
     {
         return mDofElements[dofType];
@@ -170,8 +165,8 @@ public:
 
     //! @brief nonconst Getter for DofElements
     //! @param dofType dof type
-    //! @return reference to TElement. This is implicitly casted to a reference ElementInterface when accessed via
-    //! ElementCollection
+    //! @return reference to a the DofElementFem. This is implicitly casted to a reference
+    //! DofElementInterface when accessed via ElementCollection
     DofElementFem& DofElement(DofType dofType)
     {
         return mDofElements.At(dofType);

--- a/nuto/mechanics/elements/ElementCollection.h
+++ b/nuto/mechanics/elements/ElementCollection.h
@@ -104,7 +104,7 @@ private:
     const Shape& mShape;
 };
 
-using ElementCollectionFem = ElementCollectionImpl<NuTo::ElementFem<NodeSimple>>;
+using ElementCollectionFem = ElementCollectionImpl<NuTo::DofElementFem>;
 
 template <int TDimParameter>
 using ElementCollectionIga = ElementCollectionImpl<NuTo::ElementIga<TDimParameter>>;

--- a/nuto/mechanics/elements/ElementCollection.h
+++ b/nuto/mechanics/elements/ElementCollection.h
@@ -104,7 +104,7 @@ private:
     const Shape& mShape;
 };
 
-using ElementCollectionFem = ElementCollectionImpl<NuTo::ElementFem>;
+using ElementCollectionFem = ElementCollectionImpl<NuTo::ElementFem<NodeSimple>>;
 
 template <int TDimParameter>
 using ElementCollectionIga = ElementCollectionImpl<NuTo::ElementIga<TDimParameter>>;

--- a/nuto/mechanics/elements/ElementCollection.h
+++ b/nuto/mechanics/elements/ElementCollection.h
@@ -33,11 +33,11 @@ template <typename TCoordinateElement, typename TDofElement>
 class ElementCollectionImpl : public ElementCollection
 {
 public:
-    static_assert(std::is_base_of<DofElementInterface, TDofElement>::value,
-                  "TElement must be a descendant of DofElementInterface");
+    static_assert(std::is_base_of<CoordinateElementInterface, TCoordinateElement>::value,
+                  "TCoordinateElement must be a descendant of CoordinateElementInterface");
 
     static_assert(std::is_base_of<DofElementInterface, TDofElement>::value,
-                  "TElement must be a descendant of CoordinateElementInterface");
+                  "TDofElement must be a descendant of DofElementInterface");
 
     ElementCollectionImpl(TCoordinateElement coordinateElement)
         : mCoordinateElement(coordinateElement)

--- a/nuto/mechanics/elements/ElementCollection.h
+++ b/nuto/mechanics/elements/ElementCollection.h
@@ -1,7 +1,8 @@
 #pragma once
 #include "nuto/mechanics/elements/ElementInterface.h"
 #include "nuto/mechanics/dofs/DofContainer.h"
-#include "nuto/mechanics/elements/ElementFem.h"
+#include "nuto/mechanics/elements/CoordinateElementFem.h"
+#include "nuto/mechanics/elements/DofElementFem.h"
 #include "nuto/mechanics/elements/ElementIga.h"
 
 namespace NuTo
@@ -119,11 +120,6 @@ using ElementCollectionIga = ElementCollectionImpl<NuTo::ElementIga<TDimParamete
 class ElementCollectionFem : public ElementCollection
 {
 public:
-    static_assert(std::is_base_of<ElementInterface, CoordinateElementFem>::value,
-                  "TElement must be a descendant of ElementInterface");
-    static_assert(std::is_base_of<ElementInterface, DofElementFem>::value,
-                  "TElement must be a descendant of ElementInterface");
-
     ElementCollectionFem(CoordinateElementFem& coordinateElement)
         : mCoordinateElement(coordinateElement)
         , mShape(coordinateElement.GetShape())

--- a/nuto/mechanics/elements/ElementFem.h
+++ b/nuto/mechanics/elements/ElementFem.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <vector>
-#include "nuto/mechanics/nodes/NodeCoordinates.h"
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/CoordinateNode.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 #include "nuto/mechanics/elements/ElementInterface.h"
 #include "nuto/mechanics/interpolation/InterpolationSimple.h"
 #include "nuto/mechanics/cell/Matrix.h"
@@ -12,8 +12,8 @@ namespace NuTo
 template <typename TNode>
 class ElementFem;
 
-typedef ElementFem<NodeCoordinates> CoordinateElementFem;
-typedef ElementFem<NodeSimple> DofElementFem;
+typedef ElementFem<CoordinateNode> CoordinateElementFem;
+typedef ElementFem<DofNode> DofElementFem;
 
 
 template <typename TNode>

--- a/nuto/mechanics/elements/ElementFem.h
+++ b/nuto/mechanics/elements/ElementFem.h
@@ -66,20 +66,7 @@ public:
         return GetNode(0).GetNumValues();
     }
 
-    Eigen::VectorXi GetDofNumbering() const override
-    {
-        Eigen::VectorXi dofNumbering(GetNumNodes() * GetDofDimension());
-        int i = 0;
-        for (int iNode = 0; iNode < GetNumNodes(); ++iNode)
-        {
-            const auto& node = GetNode(iNode);
-            for (int iDof = 0; iDof < GetDofDimension(); ++iDof)
-            {
-                dofNumbering[i++] = node.GetDofNumber(iDof);
-            }
-        }
-        return dofNumbering;
-    }
+    Eigen::VectorXi GetDofNumbering() const override;
 
     int GetNumNodes() const override
     {
@@ -114,4 +101,50 @@ private:
     std::reference_wrapper<const InterpolationSimple> mInterpolation;
     const Shape& mShape;
 };
+
+template <>
+inline NodeValues ElementFem<DofNode>::ExtractNodeValues(int instance) const
+{
+    const int dim = GetDofDimension();
+    Eigen::VectorXd nodeValues(GetNumNodes() * dim);
+    for (int i = 0; i < GetNumNodes(); ++i)
+        nodeValues.segment(dim * i, dim) = GetNode(i).GetValues(instance);
+    return nodeValues;
+}
+
+template <>
+inline NodeValues ElementFem<CoordinateNode>::ExtractNodeValues(int instance) const
+{
+    // Solve this later, by using type traits
+    assert(instance == 0 && "Coordinate nodes can have only 1 instance");
+
+
+    const int dim = GetDofDimension();
+    Eigen::VectorXd nodeValues(GetNumNodes() * dim);
+    for (int i = 0; i < GetNumNodes(); ++i)
+        nodeValues.segment(dim * i, dim) = GetNode(i).GetCoordinates();
+    return nodeValues;
+}
+
+template <>
+inline Eigen::VectorXi ElementFem<CoordinateNode>::GetDofNumbering() const
+{
+    assert(false && "Coordinate nodes have no dof numbering");
+}
+
+template <>
+inline Eigen::VectorXi ElementFem<DofNode>::GetDofNumbering() const
+{
+    Eigen::VectorXi dofNumbering(GetNumNodes() * GetDofDimension());
+    int i = 0;
+    for (int iNode = 0; iNode < GetNumNodes(); ++iNode)
+    {
+        const auto& node = GetNode(iNode);
+        for (int iDof = 0; iDof < GetDofDimension(); ++iDof)
+        {
+            dofNumbering[i++] = node.GetDofNumber(iDof);
+        }
+    }
+    return dofNumbering;
+}
 } /* NuTo */

--- a/nuto/mechanics/elements/ElementFem.h
+++ b/nuto/mechanics/elements/ElementFem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include "nuto/mechanics/nodes/NodeCoordinates.h"
 #include "nuto/mechanics/nodes/NodeSimple.h"
 #include "nuto/mechanics/elements/ElementInterface.h"
 #include "nuto/mechanics/interpolation/InterpolationSimple.h"

--- a/nuto/mechanics/elements/ElementFem.h
+++ b/nuto/mechanics/elements/ElementFem.h
@@ -9,6 +9,12 @@
 
 namespace NuTo
 {
+template <typename TNode>
+class ElementFem;
+
+typedef ElementFem<NodeCoordinates> CoordinateElementFem;
+typedef ElementFem<NodeSimple> DofElementFem;
+
 
 template <typename TNode>
 class ElementFem : public ElementInterface

--- a/nuto/mechanics/elements/ElementFem.h
+++ b/nuto/mechanics/elements/ElementFem.h
@@ -103,7 +103,7 @@ private:
 };
 
 template <>
-inline NodeValues ElementFem<DofNode>::ExtractNodeValues(int instance) const
+inline Eigen::VectorXd ElementFem<DofNode>::ExtractNodeValues(int instance) const
 {
     const int dim = GetDofDimension();
     Eigen::VectorXd nodeValues(GetNumNodes() * dim);
@@ -113,7 +113,7 @@ inline NodeValues ElementFem<DofNode>::ExtractNodeValues(int instance) const
 }
 
 template <>
-inline NodeValues ElementFem<CoordinateNode>::ExtractNodeValues(int instance) const
+inline Eigen::VectorXd ElementFem<CoordinateNode>::ExtractNodeValues(int instance) const
 {
     // Solve this later, by using type traits
     assert(instance == 0 && "Coordinate nodes can have only 1 instance");

--- a/nuto/mechanics/elements/ElementFem.h
+++ b/nuto/mechanics/elements/ElementFem.h
@@ -46,32 +46,33 @@ public:
         return nodeValues;
     }
 
-    Eigen::MatrixXd GetNMatrix(NaturalCoords ipCoords) const override
+    virtual Eigen::MatrixXd GetNMatrix(NaturalCoords ipCoords) const override
     {
         return Matrix::N(Interpolation().GetShapeFunctions(ipCoords), Interpolation().GetNumNodes(), GetDofDimension());
     }
 
-    Eigen::VectorXd GetShapeFunctions(NaturalCoords ipCoords) const override
+    virtual Eigen::VectorXd GetShapeFunctions(NaturalCoords ipCoords) const override
     {
         return Interpolation().GetShapeFunctions(ipCoords);
     }
 
-    Eigen::MatrixXd GetDerivativeShapeFunctions(NaturalCoords ipCoords) const override
+    virtual Eigen::MatrixXd GetDerivativeShapeFunctions(NaturalCoords ipCoords) const override
     {
         return Interpolation().GetDerivativeShapeFunctions(ipCoords);
     }
 
-    int GetDofDimension() const override
+    virtual int GetDofDimension() const override
     {
         return GetNode(0).GetNumValues();
     }
 
     Eigen::VectorXi GetDofNumbering() const override;
 
-    int GetNumNodes() const override
+    virtual int GetNumNodes() const override
     {
         return mNodes.size();
     }
+
 
     const InterpolationSimple& Interpolation() const
     {

--- a/nuto/mechanics/elements/ElementFem.h
+++ b/nuto/mechanics/elements/ElementFem.h
@@ -10,20 +10,20 @@
 namespace NuTo
 {
 
+template <typename TNode>
 class ElementFem : public ElementInterface
 {
 public:
-    ElementFem(std::vector<NodeSimple*> nodes, const InterpolationSimple& interpolation)
+    ElementFem(std::vector<TNode*> nodes, const InterpolationSimple& interpolation)
         : mInterpolation(interpolation)
         , mShape(interpolation.GetShape())
     {
-        for (NodeSimple* node : nodes)
+        for (TNode* node : nodes)
             mNodes.push_back(*node);
         assert(static_cast<int>(mNodes.size()) == interpolation.GetNumNodes());
     }
 
-    ElementFem(std::initializer_list<std::reference_wrapper<NuTo::NodeSimple>> nodes,
-               const InterpolationSimple& interpolation)
+    ElementFem(std::initializer_list<std::reference_wrapper<TNode>> nodes, const InterpolationSimple& interpolation)
         : mNodes(nodes)
         , mInterpolation(interpolation)
         , mShape(interpolation.GetShape())
@@ -85,14 +85,14 @@ public:
         return mInterpolation;
     }
 
-    NodeSimple& GetNode(int i)
+    TNode& GetNode(int i)
     {
         assert(i < static_cast<int>(mNodes.size()));
         return mNodes[i];
     }
 
 
-    const NodeSimple& GetNode(int i) const
+    const TNode& GetNode(int i) const
     {
         assert(i < static_cast<int>(mNodes.size()));
         return mNodes[i];
@@ -104,7 +104,7 @@ public:
     }
 
 private:
-    std::vector<std::reference_wrapper<NodeSimple>> mNodes;
+    std::vector<std::reference_wrapper<TNode>> mNodes;
     std::reference_wrapper<const InterpolationSimple> mInterpolation;
     const Shape& mShape;
 };

--- a/nuto/mechanics/elements/ElementIga.h
+++ b/nuto/mechanics/elements/ElementIga.h
@@ -2,14 +2,14 @@
 
 #include <vector>
 #include "nuto/mechanics/nodes/DofNode.h"
-#include "nuto/mechanics/elements/ElementInterface.h"
+#include "nuto/mechanics/elements/DofElementInterface.h"
 #include "nuto/mechanics/iga/Nurbs.h"
 #include "nuto/mechanics/cell/Matrix.h"
 
 namespace NuTo
 {
 template <int TDimParameter>
-class ElementIga : public ElementInterface
+class ElementIga : public DofElementInterface
 {
 public:
     ElementIga(const std::array<int, TDimParameter>& knotIDs, const Nurbs<TDimParameter>& NurbsGeometry)

--- a/nuto/mechanics/elements/ElementIga.h
+++ b/nuto/mechanics/elements/ElementIga.h
@@ -31,8 +31,7 @@ public:
     }
 
     //! @brief extracts all node values of this element
-    //! @remark virtual to make it testable
-    virtual Eigen::VectorXd ExtractNodeValues(int instance = 0) const override
+    Eigen::VectorXd ExtractNodeValues(int instance = 0) const override
     {
         return NurbsGeometry().GetControlPointsElement(mKnotIDs, instance);
     }

--- a/nuto/mechanics/elements/ElementIga.h
+++ b/nuto/mechanics/elements/ElementIga.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <vector>
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 #include "nuto/mechanics/elements/ElementInterface.h"
 #include "nuto/mechanics/iga/Nurbs.h"
 #include "nuto/mechanics/cell/Matrix.h"

--- a/nuto/mechanics/elements/ElementInterface.h
+++ b/nuto/mechanics/elements/ElementInterface.h
@@ -10,28 +10,11 @@ class ElementInterface
 public:
     virtual ~ElementInterface() noexcept = default;
 
-    //! @brief extracts all node values of this element
-    //!
-    //! They are ordered in blocks belonging to a node, e.g:
-    //! coordinate Nodes in 3D:
-    //!   NodeValues: (x1,y1,z1, x2,y2,z2, ...)
-    virtual Eigen::VectorXd ExtractNodeValues(int instance = 0) const = 0;
-
-    virtual int GetDofDimension() const = 0;
-
-    //! @brief extract the dof numbers from its nodes.
-    //! @remark They have to be in the same order as defined in ExtractNodeValues()
-    virtual Eigen::VectorXi GetDofNumbering() const = 0;
     virtual int GetNumNodes() const = 0;
+    virtual int GetDofDimension() const = 0;
     virtual Eigen::MatrixXd GetNMatrix(NaturalCoords ipCoords) const = 0;
     virtual Eigen::VectorXd GetShapeFunctions(NaturalCoords ipCoords) const = 0;
     virtual Eigen::MatrixXd GetDerivativeShapeFunctions(NaturalCoords ipCoords) const = 0;
 };
-
-inline Eigen::VectorXd Interpolate(const ElementInterface& element, NaturalCoords ipCoords)
-{
-    return element.GetNMatrix(ipCoords) * element.ExtractNodeValues();
-}
-
 
 } /* NuTo */

--- a/nuto/mechanics/iga/Nurbs.h
+++ b/nuto/mechanics/iga/Nurbs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 #include "nuto/base/Exception.h"
 #include <array>
 #include <eigen3/Eigen/Dense>
@@ -31,7 +31,7 @@ public:
     //! @param knots knot vector
     //! @param controlPoints control points
     Nurbs(const std::array<std::vector<double>, TDimParameter>& knots,
-          const std::vector<std::vector<NodeSimple*>>& controlPoints, const std::vector<std::vector<double>>& weights,
+          const std::vector<std::vector<DofNode*>>& controlPoints, const std::vector<std::vector<double>>& weights,
           const std::array<int, TDimParameter>& degree)
         : mKnots(knots)
         , mControlPoints(controlPoints)
@@ -327,7 +327,7 @@ private:
     std::array<std::vector<double>, TDimParameter> mKnots;
 
     //! @brief Control points of the BSpline curve (# rows = num control points)
-    std::vector<std::vector<NodeSimple*>> mControlPoints;
+    std::vector<std::vector<DofNode*>> mControlPoints;
 
     //! @brief Weights to NURBS
     std::vector<std::vector<double>> mWeights;

--- a/nuto/mechanics/mesh/GeometryMeshFem.cpp
+++ b/nuto/mechanics/mesh/GeometryMeshFem.cpp
@@ -19,9 +19,9 @@ CoordinateNode& GeometryMeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double
         if ((globalNodeCoords - coords).isMuchSmallerThan(tol, 1))
             return node;
     }
-    std::stringstream coordsString;
-    coordsString << coords.transpose();
-    throw NuTo::Exception(__PRETTY_FUNCTION__, "There is no coordinate node at " + coordsString.str());
+    std::stringstream message;
+    message << "There is no coordinate node at " << coords.transpose();
+    throw NuTo::Exception(__PRETTY_FUNCTION__, message.str());
 }
 
 Group<CoordinateNode> GeometryMeshFem::NodesAtAxis(eDirection direction, double axisOffset /* = 0.*/,

--- a/nuto/mechanics/mesh/GeometryMeshFem.cpp
+++ b/nuto/mechanics/mesh/GeometryMeshFem.cpp
@@ -13,9 +13,8 @@ InterpolationSimple& GeometryMeshFem::CreateInterpolation(const InterpolationSim
 
 CoordinateNode& GeometryMeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* = 1.e-10 */)
 {
-    for (auto& element : this->Elements)
+    for (auto& coordinateElement : this->Elements)
     {
-        auto& coordinateElement = element.CoordinateElement();
         for (int iNode = 0; iNode < coordinateElement.Interpolation().GetNumNodes(); ++iNode)
         {
             Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetCoordinates();
@@ -33,9 +32,8 @@ Group<CoordinateNode> GeometryMeshFem::NodesAtAxis(eDirection direction, double 
 {
     Group<CoordinateNode> group;
     const int directionComponent = ToComponentIndex(direction);
-    for (auto& element : this->Elements)
+    for (auto& coordinateElement : this->Elements)
     {
-        auto& coordinateElement = element.CoordinateElement();
         for (int iNode = 0; iNode < coordinateElement.GetNumNodes(); ++iNode)
         {
             Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetCoordinates();
@@ -49,15 +47,15 @@ Group<CoordinateNode> GeometryMeshFem::NodesAtAxis(eDirection direction, double 
 Group<CoordinateNode> GeometryMeshFem::NodesTotal()
 {
     Group<CoordinateNode> group;
-    for (auto& element : this->Elements)
-        for (int iNode = 0; iNode < element.CoordinateElement().Interpolation().GetNumNodes(); ++iNode)
-            group.Add(element.CoordinateElement().GetNode(iNode));
+    for (auto& coordinateElement : this->Elements)
+        for (int iNode = 0; iNode < coordinateElement.Interpolation().GetNumNodes(); ++iNode)
+            group.Add(coordinateElement.GetNode(iNode));
     return group;
 }
 
-Group<ElementCollectionFem> GeometryMeshFem::ElementsTotal()
+Group<CoordinateElementFem> GeometryMeshFem::ElementsTotal()
 {
-    Group<ElementCollectionFem> elements;
+    Group<CoordinateElementFem> elements;
     for (auto& element : this->Elements)
         elements.Add(element);
     return elements;

--- a/nuto/mechanics/mesh/GeometryMeshFem.cpp
+++ b/nuto/mechanics/mesh/GeometryMeshFem.cpp
@@ -13,14 +13,11 @@ InterpolationSimple& GeometryMeshFem::CreateInterpolation(const InterpolationSim
 
 CoordinateNode& GeometryMeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* = 1.e-10 */)
 {
-    for (auto& coordinateElement : this->Elements)
+    for (auto& node : this->CoordinateNodes)
     {
-        for (int iNode = 0; iNode < coordinateElement.Interpolation().GetNumNodes(); ++iNode)
-        {
-            Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetCoordinates();
-            if ((globalNodeCoords - coords).isMuchSmallerThan(tol, 1))
-                return coordinateElement.GetNode(iNode);
-        }
+        Eigen::VectorXd globalNodeCoords = node.GetCoordinates();
+        if ((globalNodeCoords - coords).isMuchSmallerThan(tol, 1))
+            return node;
     }
     std::stringstream coordsString;
     coordsString << coords.transpose();
@@ -32,14 +29,11 @@ Group<CoordinateNode> GeometryMeshFem::NodesAtAxis(eDirection direction, double 
 {
     Group<CoordinateNode> group;
     const int directionComponent = ToComponentIndex(direction);
-    for (auto& coordinateElement : this->Elements)
+    for (auto& node : this->CoordinateNodes)
     {
-        for (int iNode = 0; iNode < coordinateElement.GetNumNodes(); ++iNode)
-        {
-            Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetCoordinates();
-            if (std::abs(globalNodeCoords[directionComponent] - axisOffset) < tol)
-                group.Add(coordinateElement.GetNode(iNode));
-        }
+        Eigen::VectorXd globalNodeCoords = node.GetCoordinates();
+        if (std::abs(globalNodeCoords[directionComponent] - axisOffset) < tol)
+            group.Add(node);
     }
     return group;
 }
@@ -47,9 +41,8 @@ Group<CoordinateNode> GeometryMeshFem::NodesAtAxis(eDirection direction, double 
 Group<CoordinateNode> GeometryMeshFem::NodesTotal()
 {
     Group<CoordinateNode> group;
-    for (auto& coordinateElement : this->Elements)
-        for (int iNode = 0; iNode < coordinateElement.Interpolation().GetNumNodes(); ++iNode)
-            group.Add(coordinateElement.GetNode(iNode));
+    for (auto& node : this->CoordinateNodes)
+        group.Add(node);
     return group;
 }
 

--- a/nuto/mechanics/mesh/GeometryMeshFem.cpp
+++ b/nuto/mechanics/mesh/GeometryMeshFem.cpp
@@ -1,0 +1,64 @@
+#include "nuto/mechanics/mesh/GeometryMeshFem.h"
+
+#include <sstream>
+#include "nuto/base/Exception.h"
+
+using namespace NuTo;
+
+InterpolationSimple& GeometryMeshFem::CreateInterpolation(const InterpolationSimple& interpolation)
+{
+    mInterpolations.push_back(interpolation.Clone());
+    return *mInterpolations.rbegin()->get();
+}
+
+CoordinateNode& GeometryMeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* = 1.e-10 */)
+{
+    for (auto& element : this->Elements)
+    {
+        auto& coordinateElement = element.CoordinateElement();
+        for (int iNode = 0; iNode < coordinateElement.Interpolation().GetNumNodes(); ++iNode)
+        {
+            Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetCoordinates();
+            if ((globalNodeCoords - coords).isMuchSmallerThan(tol, 1))
+                return coordinateElement.GetNode(iNode);
+        }
+    }
+    std::stringstream coordsString;
+    coordsString << coords.transpose();
+    throw NuTo::Exception(__PRETTY_FUNCTION__, "There is no coordinate node at " + coordsString.str());
+}
+
+Group<CoordinateNode> GeometryMeshFem::NodesAtAxis(eDirection direction, double axisOffset /* = 0.*/,
+                                                   double tol /* = 1.e-10 */)
+{
+    Group<CoordinateNode> group;
+    const int directionComponent = ToComponentIndex(direction);
+    for (auto& element : this->Elements)
+    {
+        auto& coordinateElement = element.CoordinateElement();
+        for (int iNode = 0; iNode < coordinateElement.GetNumNodes(); ++iNode)
+        {
+            Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetCoordinates();
+            if (std::abs(globalNodeCoords[directionComponent] - axisOffset) < tol)
+                group.Add(coordinateElement.GetNode(iNode));
+        }
+    }
+    return group;
+}
+
+Group<CoordinateNode> GeometryMeshFem::NodesTotal()
+{
+    Group<CoordinateNode> group;
+    for (auto& element : this->Elements)
+        for (int iNode = 0; iNode < element.CoordinateElement().Interpolation().GetNumNodes(); ++iNode)
+            group.Add(element.CoordinateElement().GetNode(iNode));
+    return group;
+}
+
+Group<ElementCollectionFem> GeometryMeshFem::ElementsTotal()
+{
+    Group<ElementCollectionFem> elements;
+    for (auto& element : this->Elements)
+        elements.Add(element);
+    return elements;
+}

--- a/nuto/mechanics/mesh/GeometryMeshFem.h
+++ b/nuto/mechanics/mesh/GeometryMeshFem.h
@@ -1,0 +1,61 @@
+#pragma once
+#include "nuto/base/Group.h"
+#include "nuto/base/ValueVector.h"
+#include "nuto/mechanics/DirectionEnum.h"
+#include "nuto/mechanics/nodes/DofNode.h"
+#include "nuto/mechanics/elements/ElementCollection.h"
+
+#include <memory>
+#include <vector>
+
+namespace NuTo
+{
+//! @brief contains the nodes, elements and interpolations for a classic finite element mesh
+//! @remark Elements contain references to nodes. Thus, a copy of GeometryMeshFem is not trivially possible and only move is
+//! allowed
+class GeometryMeshFem
+{
+public:
+    GeometryMeshFem() = default;
+
+    GeometryMeshFem(const GeometryMeshFem&) = delete;
+    GeometryMeshFem& operator=(const GeometryMeshFem&) = delete;
+
+    GeometryMeshFem(GeometryMeshFem&&) = default;
+    GeometryMeshFem& operator=(GeometryMeshFem&&) = default;
+
+    //! @brief adds a clone of `interpolation` to the mesh (prototype pattern)
+    //! @param interpolation interpolation that is cloned and added
+    //! @return reference to the cloned object
+    InterpolationSimple& CreateInterpolation(const InterpolationSimple& interpolation);
+
+    //! @brief selects a coordinate at given `coords`
+    //! @param coords global coordinates
+    //! @param tol selection tolerance
+    //! @return reference to the selected node, throws, if no node is found
+    CoordinateNode& NodeAtCoordinate(Eigen::VectorXd coords, double tol = 1.e-10);
+
+    //! @brief selects all coordinate nodes where the `coord` in `direction` is within `tol`
+    //! @param direction ::X, ::Y, or ::Z
+    //! @param axisOffset distance of the node to the axis
+    //! @param tol selection tolerance
+    //! @return group with selected nodes, the group may be empty if no nodes were found
+    Group<CoordinateNode> NodesAtAxis(eDirection direction, double axisOffset = 0., double tol = 1.e-10);
+
+    //! @brief selects all coordinate nodes
+    //! @return group containing all selected nodes
+    Group<CoordinateNode> NodesTotal();
+
+    //! @brief selects all element collections
+    //! @return group containing all element collections
+    Group<ElementCollectionFem> ElementsTotal();
+
+public:
+    ValueVector<CoordinateNode> CoordinateNodes;
+    ValueVector<DofNode> Nodes;
+    ValueVector<ElementCollectionFem> Elements;
+
+private:
+    std::vector<std::unique_ptr<InterpolationSimple>> mInterpolations;
+};
+} /* NuTo */

--- a/nuto/mechanics/mesh/GeometryMeshFem.h
+++ b/nuto/mechanics/mesh/GeometryMeshFem.h
@@ -48,12 +48,11 @@ public:
 
     //! @brief selects all element collections
     //! @return group containing all element collections
-    Group<ElementCollectionFem> ElementsTotal();
+    Group<CoordinateElementFem> ElementsTotal();
 
 public:
     ValueVector<CoordinateNode> CoordinateNodes;
-    ValueVector<DofNode> Nodes;
-    ValueVector<ElementCollectionFem> Elements;
+    ValueVector<CoordinateElementFem> Elements;
 
 private:
     std::vector<std::unique_ptr<InterpolationSimple>> mInterpolations;

--- a/nuto/mechanics/mesh/MeshFem.cpp
+++ b/nuto/mechanics/mesh/MeshFem.cpp
@@ -11,9 +11,9 @@ using namespace NuTo;
 MeshFem::MeshFem(const GeometryMeshFem& geometryMesh)
     : mGeometryMesh(geometryMesh)
 {
-    for (auto cElm : geometryMesh.Elements)
+    for (auto& cElm : geometryMesh.Elements)
     {
-        Elements.Add(cElm);
+        Elements.Add(ElementCollectionFem(cElm));
     }
 }
 

--- a/nuto/mechanics/mesh/MeshFem.cpp
+++ b/nuto/mechanics/mesh/MeshFem.cpp
@@ -46,16 +46,6 @@ DofNode& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, DofType dofType, doub
                           "There is no node for dof type " + dofType.GetName() + " at " + coordsString.str());
 }
 
-CoordinateNode& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* = 1.e-10 */)
-{
-    return mGeometryMesh.NodeAtCoordinate(coords, tol);
-}
-
-Group<CoordinateNode> MeshFem::NodesAtAxis(eDirection direction, double axisOffset /* = 0.*/, double tol /* = 1.e-10 */)
-{
-    return mGeometryMesh.NodesAtAxis(direction, axisOffset, tol);
-}
-
 Group<DofNode> MeshFem::NodesAtAxis(eDirection direction, DofType dofType, double axisOffset /* = 0.*/,
                                     double tol /* = 1.e-10 */)
 {
@@ -78,11 +68,6 @@ Group<DofNode> MeshFem::NodesAtAxis(eDirection direction, DofType dofType, doubl
         }
     }
     return group;
-}
-
-Group<CoordinateNode> MeshFem::NodesTotal()
-{
-    return mGeometryMesh.NodesTotal();
 }
 
 Group<DofNode> MeshFem::NodesTotal(DofType d)

--- a/nuto/mechanics/mesh/MeshFem.cpp
+++ b/nuto/mechanics/mesh/MeshFem.cpp
@@ -1,9 +1,21 @@
 #include "nuto/mechanics/mesh/MeshFem.h"
 
+#include "nuto/mechanics/mesh/GeometryMeshFem.h"
+
 #include <sstream>
 #include "nuto/base/Exception.h"
 
+
 using namespace NuTo;
+
+MeshFem::MeshFem(const GeometryMeshFem& geometryMesh)
+    : mGeometryMesh(geometryMesh)
+{
+    for (auto cElm : geometryMesh.Elements)
+    {
+        Elements.Add(cElm);
+    }
+}
 
 InterpolationSimple& MeshFem::CreateInterpolation(const InterpolationSimple& interpolation)
 {

--- a/nuto/mechanics/mesh/MeshFem.cpp
+++ b/nuto/mechanics/mesh/MeshFem.cpp
@@ -11,7 +11,7 @@ InterpolationSimple& MeshFem::CreateInterpolation(const InterpolationSimple& int
     return *mInterpolations.rbegin()->get();
 }
 
-NodeSimple& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, DofType dofType, double tol /* = 1.e-10 */)
+DofNode& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, DofType dofType, double tol /* = 1.e-10 */)
 {
     for (auto& element : this->Elements)
     {
@@ -34,7 +34,7 @@ NodeSimple& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, DofType dofType, d
                           "There is no node for dof type " + dofType.GetName() + " at " + coordsString.str());
 }
 
-NodeCoordinates& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* = 1.e-10 */)
+CoordinateNode& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* = 1.e-10 */)
 {
     for (auto& element : this->Elements)
     {
@@ -51,10 +51,9 @@ NodeCoordinates& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /*
     throw NuTo::Exception(__PRETTY_FUNCTION__, "There is no coordinate node at " + coordsString.str());
 }
 
-Group<NodeCoordinates> MeshFem::NodesAtAxis(eDirection direction, double axisOffset /* = 0.*/,
-                                            double tol /* = 1.e-10 */)
+Group<CoordinateNode> MeshFem::NodesAtAxis(eDirection direction, double axisOffset /* = 0.*/, double tol /* = 1.e-10 */)
 {
-    Group<NodeCoordinates> group;
+    Group<CoordinateNode> group;
     const int directionComponent = ToComponentIndex(direction);
     for (auto& element : this->Elements)
     {
@@ -69,10 +68,10 @@ Group<NodeCoordinates> MeshFem::NodesAtAxis(eDirection direction, double axisOff
     return group;
 }
 
-Group<NodeSimple> MeshFem::NodesAtAxis(eDirection direction, DofType dofType, double axisOffset /* = 0.*/,
-                                       double tol /* = 1.e-10 */)
+Group<DofNode> MeshFem::NodesAtAxis(eDirection direction, DofType dofType, double axisOffset /* = 0.*/,
+                                    double tol /* = 1.e-10 */)
 {
-    Group<NodeSimple> group;
+    Group<DofNode> group;
     const int directionComponent = ToComponentIndex(direction);
     for (auto& element : this->Elements)
     {
@@ -93,18 +92,18 @@ Group<NodeSimple> MeshFem::NodesAtAxis(eDirection direction, DofType dofType, do
     return group;
 }
 
-Group<NodeCoordinates> MeshFem::NodesTotal()
+Group<CoordinateNode> MeshFem::NodesTotal()
 {
-    Group<NodeCoordinates> group;
+    Group<CoordinateNode> group;
     for (auto& element : this->Elements)
         for (int iNode = 0; iNode < element.CoordinateElement().Interpolation().GetNumNodes(); ++iNode)
             group.Add(element.CoordinateElement().GetNode(iNode));
     return group;
 }
 
-Group<NodeSimple> MeshFem::NodesTotal(DofType d)
+Group<DofNode> MeshFem::NodesTotal(DofType d)
 {
-    Group<NodeSimple> group;
+    Group<DofNode> group;
     for (auto& element : this->Elements)
     {
         if (!element.Has(d))

--- a/nuto/mechanics/mesh/MeshFem.cpp
+++ b/nuto/mechanics/mesh/MeshFem.cpp
@@ -8,7 +8,7 @@
 
 using namespace NuTo;
 
-MeshFem::MeshFem(const GeometryMeshFem& geometryMesh)
+MeshFem::MeshFem(GeometryMeshFem& geometryMesh)
     : mGeometryMesh(geometryMesh)
 {
     for (auto& cElm : geometryMesh.Elements)
@@ -48,19 +48,7 @@ DofNode& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, DofType dofType, doub
 
 CoordinateNode& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* = 1.e-10 */)
 {
-    for (auto& element : this->Elements)
-    {
-        auto& coordinateElement = element.CoordinateElement();
-        for (int iNode = 0; iNode < coordinateElement.Interpolation().GetNumNodes(); ++iNode)
-        {
-            Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetCoordinates();
-            if ((globalNodeCoords - coords).isMuchSmallerThan(tol, 1))
-                return coordinateElement.GetNode(iNode);
-        }
-    }
-    std::stringstream coordsString;
-    coordsString << coords.transpose();
-    throw NuTo::Exception(__PRETTY_FUNCTION__, "There is no coordinate node at " + coordsString.str());
+    return mGeometryMesh.NodeAtCoordinate(coords, tol);
 }
 
 Group<CoordinateNode> MeshFem::NodesAtAxis(eDirection direction, double axisOffset /* = 0.*/, double tol /* = 1.e-10 */)

--- a/nuto/mechanics/mesh/MeshFem.cpp
+++ b/nuto/mechanics/mesh/MeshFem.cpp
@@ -34,7 +34,7 @@ NodeSimple& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, DofType dofType, d
                           "There is no node for dof type " + dofType.GetName() + " at " + coordsString.str());
 }
 
-NodeSimple& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* = 1.e-10 */)
+NodeCoordinates& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* = 1.e-10 */)
 {
     for (auto& element : this->Elements)
     {
@@ -51,9 +51,10 @@ NodeSimple& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* = 1.
     throw NuTo::Exception(__PRETTY_FUNCTION__, "There is no coordinate node at " + coordsString.str());
 }
 
-Group<NodeSimple> MeshFem::NodesAtAxis(eDirection direction, double axisOffset /* = 0.*/, double tol /* = 1.e-10 */)
+Group<NodeCoordinates> MeshFem::NodesAtAxis(eDirection direction, double axisOffset /* = 0.*/,
+                                            double tol /* = 1.e-10 */)
 {
-    Group<NodeSimple> group;
+    Group<NodeCoordinates> group;
     const int directionComponent = ToComponentIndex(direction);
     for (auto& element : this->Elements)
     {
@@ -92,9 +93,9 @@ Group<NodeSimple> MeshFem::NodesAtAxis(eDirection direction, DofType dofType, do
     return group;
 }
 
-Group<NodeSimple> MeshFem::NodesTotal()
+Group<NodeCoordinates> MeshFem::NodesTotal()
 {
-    Group<NodeSimple> group;
+    Group<NodeCoordinates> group;
     for (auto& element : this->Elements)
         for (int iNode = 0; iNode < element.CoordinateElement().Interpolation().GetNumNodes(); ++iNode)
             group.Add(element.CoordinateElement().GetNode(iNode));

--- a/nuto/mechanics/mesh/MeshFem.cpp
+++ b/nuto/mechanics/mesh/MeshFem.cpp
@@ -53,19 +53,7 @@ CoordinateNode& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* 
 
 Group<CoordinateNode> MeshFem::NodesAtAxis(eDirection direction, double axisOffset /* = 0.*/, double tol /* = 1.e-10 */)
 {
-    Group<CoordinateNode> group;
-    const int directionComponent = ToComponentIndex(direction);
-    for (auto& element : this->Elements)
-    {
-        auto& coordinateElement = element.CoordinateElement();
-        for (int iNode = 0; iNode < coordinateElement.GetNumNodes(); ++iNode)
-        {
-            Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetCoordinates();
-            if (std::abs(globalNodeCoords[directionComponent] - axisOffset) < tol)
-                group.Add(coordinateElement.GetNode(iNode));
-        }
-    }
-    return group;
+    return mGeometryMesh.NodesAtAxis(direction, axisOffset, tol);
 }
 
 Group<DofNode> MeshFem::NodesAtAxis(eDirection direction, DofType dofType, double axisOffset /* = 0.*/,
@@ -94,11 +82,7 @@ Group<DofNode> MeshFem::NodesAtAxis(eDirection direction, DofType dofType, doubl
 
 Group<CoordinateNode> MeshFem::NodesTotal()
 {
-    Group<CoordinateNode> group;
-    for (auto& element : this->Elements)
-        for (int iNode = 0; iNode < element.CoordinateElement().Interpolation().GetNumNodes(); ++iNode)
-            group.Add(element.CoordinateElement().GetNode(iNode));
-    return group;
+    return mGeometryMesh.NodesTotal();
 }
 
 Group<DofNode> MeshFem::NodesTotal(DofType d)

--- a/nuto/mechanics/mesh/MeshFem.cpp
+++ b/nuto/mechanics/mesh/MeshFem.cpp
@@ -41,7 +41,7 @@ CoordinateNode& MeshFem::NodeAtCoordinate(Eigen::VectorXd coords, double tol /* 
         auto& coordinateElement = element.CoordinateElement();
         for (int iNode = 0; iNode < coordinateElement.Interpolation().GetNumNodes(); ++iNode)
         {
-            Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetValues();
+            Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetCoordinates();
             if ((globalNodeCoords - coords).isMuchSmallerThan(tol, 1))
                 return coordinateElement.GetNode(iNode);
         }
@@ -60,7 +60,7 @@ Group<CoordinateNode> MeshFem::NodesAtAxis(eDirection direction, double axisOffs
         auto& coordinateElement = element.CoordinateElement();
         for (int iNode = 0; iNode < coordinateElement.GetNumNodes(); ++iNode)
         {
-            Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetValues();
+            Eigen::VectorXd globalNodeCoords = coordinateElement.GetNode(iNode).GetCoordinates();
             if (std::abs(globalNodeCoords[directionComponent] - axisOffset) < tol)
                 group.Add(coordinateElement.GetNode(iNode));
         }

--- a/nuto/mechanics/mesh/MeshFem.h
+++ b/nuto/mechanics/mesh/MeshFem.h
@@ -32,12 +32,6 @@ public:
     //! @return reference to the cloned object
     InterpolationSimple& CreateInterpolation(const InterpolationSimple& interpolation);
 
-    //! @brief selects a coordinate at given `coords`
-    //! @param coords global coordinates
-    //! @param tol selection tolerance
-    //! @return reference to the selected node, throws, if no node is found
-    CoordinateNode& NodeAtCoordinate(Eigen::VectorXd coords, double tol = 1.e-10);
-
     //! @brief selects a node of type `dofType` at given `coords`
     //! @param coords global coordinates
     //! @param dofType dof type
@@ -53,20 +47,9 @@ public:
     //! @return group with selected nodes, the group may be empty if no nodes were found
     Group<DofNode> NodesAtAxis(eDirection direction, DofType dofType, double axisOffset = 0., double tol = 1.e-10);
 
-    //! @brief selects all coordinate nodes where the `coord` in `direction` is within `tol`
-    //! @param direction ::X, ::Y, or ::Z
-    //! @param axisOffset distance of the node to the axis
-    //! @param tol selection tolerance
-    //! @return group with selected nodes, the group may be empty if no nodes were found
-    Group<CoordinateNode> NodesAtAxis(eDirection direction, double axisOffset = 0., double tol = 1.e-10);
-
     //! @brief selects all nodes of `dofType`
     //! @return group containing all selected nodes
     Group<DofNode> NodesTotal(DofType dofType);
-
-    //! @brief selects all coordinate nodes
-    //! @return group containing all selected nodes
-    Group<CoordinateNode> NodesTotal();
 
     //! @brief selects all element collections
     //! @return group containing all element collections

--- a/nuto/mechanics/mesh/MeshFem.h
+++ b/nuto/mechanics/mesh/MeshFem.h
@@ -33,7 +33,7 @@ public:
     //! @param coords global coordinates
     //! @param tol selection tolerance
     //! @return reference to the selected node, throws, if no node is found
-    NodeSimple& NodeAtCoordinate(Eigen::VectorXd coords, double tol = 1.e-10);
+    NodeCoordinates& NodeAtCoordinate(Eigen::VectorXd coords, double tol = 1.e-10);
 
     //! @brief selects a node of type `dofType` at given `coords`
     //! @param coords global coordinates
@@ -55,7 +55,7 @@ public:
     //! @param axisOffset distance of the node to the axis
     //! @param tol selection tolerance
     //! @return group with selected nodes, the group may be empty if no nodes were found
-    Group<NodeSimple> NodesAtAxis(eDirection direction, double axisOffset = 0., double tol = 1.e-10);
+    Group<NodeCoordinates> NodesAtAxis(eDirection direction, double axisOffset = 0., double tol = 1.e-10);
 
     //! @brief selects all nodes of `dofType`
     //! @return group containing all selected nodes
@@ -63,7 +63,7 @@ public:
 
     //! @brief selects all coordinate nodes
     //! @return group containing all selected nodes
-    Group<NodeSimple> NodesTotal();
+    Group<NodeCoordinates> NodesTotal();
 
     //! @brief selects all element collections
     //! @return group containing all element collections
@@ -74,6 +74,7 @@ public:
     void AllocateDofInstances(DofType dofType, int numInstances);
 
 public:
+    ValueVector<NodeCoordinates> CoordinateNodes;
     ValueVector<NodeSimple> Nodes;
     ValueVector<ElementCollectionFem> Elements;
 

--- a/nuto/mechanics/mesh/MeshFem.h
+++ b/nuto/mechanics/mesh/MeshFem.h
@@ -19,7 +19,7 @@ class GeometryMeshFem;
 class MeshFem
 {
 public:
-    MeshFem(const GeometryMeshFem& geometryMesh);
+    MeshFem(GeometryMeshFem& geometryMesh);
 
     MeshFem(const MeshFem&) = delete;
     MeshFem& operator=(const MeshFem&) = delete;
@@ -77,7 +77,7 @@ public:
     void AllocateDofInstances(DofType dofType, int numInstances);
 
 public:
-    const GeometryMeshFem& mGeometryMesh;
+    GeometryMeshFem& mGeometryMesh;
     ValueVector<DofNode> Nodes;
     ValueVector<ElementCollectionFem> Elements;
 

--- a/nuto/mechanics/mesh/MeshFem.h
+++ b/nuto/mechanics/mesh/MeshFem.h
@@ -78,7 +78,6 @@ public:
 
 public:
     const GeometryMeshFem& mGeometryMesh;
-    ValueVector<CoordinateNode> CoordinateNodes;
     ValueVector<DofNode> Nodes;
     ValueVector<ElementCollectionFem> Elements;
 

--- a/nuto/mechanics/mesh/MeshFem.h
+++ b/nuto/mechanics/mesh/MeshFem.h
@@ -2,7 +2,7 @@
 #include "nuto/base/Group.h"
 #include "nuto/base/ValueVector.h"
 #include "nuto/mechanics/DirectionEnum.h"
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 #include "nuto/mechanics/elements/ElementCollection.h"
 
 #include <memory>
@@ -33,14 +33,14 @@ public:
     //! @param coords global coordinates
     //! @param tol selection tolerance
     //! @return reference to the selected node, throws, if no node is found
-    NodeCoordinates& NodeAtCoordinate(Eigen::VectorXd coords, double tol = 1.e-10);
+    CoordinateNode& NodeAtCoordinate(Eigen::VectorXd coords, double tol = 1.e-10);
 
     //! @brief selects a node of type `dofType` at given `coords`
     //! @param coords global coordinates
     //! @param dofType dof type
     //! @param tol selection tolerance
     //! @return reference to the selected node, throws, if no node is found
-    NodeSimple& NodeAtCoordinate(Eigen::VectorXd coords, DofType dofType, double tol = 1.e-10);
+    DofNode& NodeAtCoordinate(Eigen::VectorXd coords, DofType dofType, double tol = 1.e-10);
 
     //! @brief selects all nodes of type `dofType` where the `coord` in `direction` is within `tol`
     //! @param direction ::X, ::Y, or ::Z
@@ -48,22 +48,22 @@ public:
     //! @param axisOffset distance of the node to the axis
     //! @param tol selection tolerance
     //! @return group with selected nodes, the group may be empty if no nodes were found
-    Group<NodeSimple> NodesAtAxis(eDirection direction, DofType dofType, double axisOffset = 0., double tol = 1.e-10);
+    Group<DofNode> NodesAtAxis(eDirection direction, DofType dofType, double axisOffset = 0., double tol = 1.e-10);
 
     //! @brief selects all coordinate nodes where the `coord` in `direction` is within `tol`
     //! @param direction ::X, ::Y, or ::Z
     //! @param axisOffset distance of the node to the axis
     //! @param tol selection tolerance
     //! @return group with selected nodes, the group may be empty if no nodes were found
-    Group<NodeCoordinates> NodesAtAxis(eDirection direction, double axisOffset = 0., double tol = 1.e-10);
+    Group<CoordinateNode> NodesAtAxis(eDirection direction, double axisOffset = 0., double tol = 1.e-10);
 
     //! @brief selects all nodes of `dofType`
     //! @return group containing all selected nodes
-    Group<NodeSimple> NodesTotal(DofType dofType);
+    Group<DofNode> NodesTotal(DofType dofType);
 
     //! @brief selects all coordinate nodes
     //! @return group containing all selected nodes
-    Group<NodeCoordinates> NodesTotal();
+    Group<CoordinateNode> NodesTotal();
 
     //! @brief selects all element collections
     //! @return group containing all element collections
@@ -74,8 +74,8 @@ public:
     void AllocateDofInstances(DofType dofType, int numInstances);
 
 public:
-    ValueVector<NodeCoordinates> CoordinateNodes;
-    ValueVector<NodeSimple> Nodes;
+    ValueVector<CoordinateNode> CoordinateNodes;
+    ValueVector<DofNode> Nodes;
     ValueVector<ElementCollectionFem> Elements;
 
 private:

--- a/nuto/mechanics/mesh/MeshFem.h
+++ b/nuto/mechanics/mesh/MeshFem.h
@@ -10,13 +10,16 @@
 
 namespace NuTo
 {
+
+class GeometryMeshFem;
+
 //! @brief contains the nodes, elements and interpolations for a classic finite element mesh
 //! @remark Elements contain references to nodes. Thus, a copy of MeshFem is not trivially possible and only move is
 //! allowed
 class MeshFem
 {
 public:
-    MeshFem() = default;
+    MeshFem(const GeometryMeshFem& geometryMesh);
 
     MeshFem(const MeshFem&) = delete;
     MeshFem& operator=(const MeshFem&) = delete;
@@ -74,6 +77,7 @@ public:
     void AllocateDofInstances(DofType dofType, int numInstances);
 
 public:
+    const GeometryMeshFem& mGeometryMesh;
     ValueVector<CoordinateNode> CoordinateNodes;
     ValueVector<DofNode> Nodes;
     ValueVector<ElementCollectionFem> Elements;

--- a/nuto/mechanics/mesh/MeshFemDofConvert.cpp
+++ b/nuto/mechanics/mesh/MeshFemDofConvert.cpp
@@ -145,7 +145,7 @@ std::vector<NodePoint> NodePointsTotal(NuTo::MeshFem* rMesh, NuTo::DofType dofTy
 
     for (auto& elementCollection : rMesh->Elements)
     {
-        const NuTo::ElementFem<NuTo::CoordinateNode>& coordinateElement = elementCollection.CoordinateElement();
+        const NuTo::CoordinateElementFem& coordinateElement = elementCollection.CoordinateElement();
 
         if (!elementCollection.Has(dofType))
             continue;
@@ -205,7 +205,7 @@ void NuTo::AddDofInterpolation(NuTo::MeshFem* rMesh, DofType dofType, Group<Elem
                 nodesForTheNewlyCreatedElement.push_back(&node);
             }
         }
-        elementCollection.AddDofElement(dofType, ElementFem<DofNode>(nodesForTheNewlyCreatedElement, interpolation));
+        elementCollection.AddDofElement(dofType, DofElementFem(nodesForTheNewlyCreatedElement, interpolation));
     }
 }
 

--- a/nuto/mechanics/mesh/MeshFemDofConvert.cpp
+++ b/nuto/mechanics/mesh/MeshFemDofConvert.cpp
@@ -145,7 +145,7 @@ std::vector<NodePoint> NodePointsTotal(NuTo::MeshFem* rMesh, NuTo::DofType dofTy
 
     for (auto& elementCollection : rMesh->Elements)
     {
-        const NuTo::ElementFem& coordinateElement = elementCollection.CoordinateElement();
+        const NuTo::ElementFem<NuTo::NodeSimple>& coordinateElement = elementCollection.CoordinateElement();
 
         if (!elementCollection.Has(dofType))
             continue;
@@ -205,7 +205,7 @@ void NuTo::AddDofInterpolation(NuTo::MeshFem* rMesh, DofType dofType, Group<Elem
                 nodesForTheNewlyCreatedElement.push_back(&node);
             }
         }
-        elementCollection.AddDofElement(dofType, ElementFem(nodesForTheNewlyCreatedElement, interpolation));
+        elementCollection.AddDofElement(dofType, ElementFem<NodeSimple>(nodesForTheNewlyCreatedElement, interpolation));
     }
 }
 

--- a/nuto/mechanics/mesh/MeshFemDofConvert.cpp
+++ b/nuto/mechanics/mesh/MeshFemDofConvert.cpp
@@ -145,7 +145,7 @@ std::vector<NodePoint> NodePointsTotal(NuTo::MeshFem* rMesh, NuTo::DofType dofTy
 
     for (auto& elementCollection : rMesh->Elements)
     {
-        const NuTo::ElementFem<NuTo::NodeSimple>& coordinateElement = elementCollection.CoordinateElement();
+        const NuTo::ElementFem<NuTo::NodeCoordinates>& coordinateElement = elementCollection.CoordinateElement();
 
         if (!elementCollection.Has(dofType))
             continue;

--- a/nuto/mechanics/mesh/MeshFemDofConvert.cpp
+++ b/nuto/mechanics/mesh/MeshFemDofConvert.cpp
@@ -97,12 +97,12 @@ private:
 
 struct NodePoint : Eigen::Vector3d // to inherit operator[]
 {
-    NodePoint(Eigen::VectorXd v, NuTo::NodeSimple& node)
+    NodePoint(Eigen::VectorXd v, NuTo::DofNode& node)
         : Eigen::Vector3d(To3D(v))
         , mNode(node)
     {
     }
-    NuTo::NodeSimple& mNode;
+    NuTo::DofNode& mNode;
 };
 
 SubBoxes<NodePoint>::Domain SetupSubBoxDomain(const NuTo::MeshFem& mesh, int numBoxesPerDirection, double eps)
@@ -145,7 +145,7 @@ std::vector<NodePoint> NodePointsTotal(NuTo::MeshFem* rMesh, NuTo::DofType dofTy
 
     for (auto& elementCollection : rMesh->Elements)
     {
-        const NuTo::ElementFem<NuTo::NodeCoordinates>& coordinateElement = elementCollection.CoordinateElement();
+        const NuTo::ElementFem<NuTo::CoordinateNode>& coordinateElement = elementCollection.CoordinateElement();
 
         if (!elementCollection.Has(dofType))
             continue;
@@ -154,7 +154,7 @@ std::vector<NodePoint> NodePointsTotal(NuTo::MeshFem* rMesh, NuTo::DofType dofTy
         {
             Eigen::Vector3d coord = To3D(Interpolate(
                     coordinateElement, elementCollection.DofElement(dofType).Interpolation().GetLocalCoords(iNode)));
-            NuTo::NodeSimple& node = elementCollection.DofElement(dofType).GetNode(iNode);
+            NuTo::DofNode& node = elementCollection.DofElement(dofType).GetNode(iNode);
             nodePoints.push_back(NodePoint(coord, node));
         }
     }
@@ -176,7 +176,7 @@ void NuTo::AddDofInterpolation(NuTo::MeshFem* rMesh, DofType dofType, Group<Elem
 
     for (auto& elementCollection : elements)
     {
-        std::vector<NodeSimple*> nodesForTheNewlyCreatedElement;
+        std::vector<DofNode*> nodesForTheNewlyCreatedElement;
 
         const auto& coordinateElement = elementCollection.CoordinateElement();
         const auto& interpolation = optionalInterpolation.value_or(coordinateElement.Interpolation());
@@ -205,7 +205,7 @@ void NuTo::AddDofInterpolation(NuTo::MeshFem* rMesh, DofType dofType, Group<Elem
                 nodesForTheNewlyCreatedElement.push_back(&node);
             }
         }
-        elementCollection.AddDofElement(dofType, ElementFem<NodeSimple>(nodesForTheNewlyCreatedElement, interpolation));
+        elementCollection.AddDofElement(dofType, ElementFem<DofNode>(nodesForTheNewlyCreatedElement, interpolation));
     }
 }
 

--- a/nuto/mechanics/mesh/MeshFemDofConvert.cpp
+++ b/nuto/mechanics/mesh/MeshFemDofConvert.cpp
@@ -107,7 +107,7 @@ struct NodePoint : Eigen::Vector3d // to inherit operator[]
 
 SubBoxes<NodePoint>::Domain SetupSubBoxDomain(const NuTo::MeshFem& mesh, int numBoxesPerDirection, double eps)
 {
-    Eigen::VectorXd start = mesh.Elements[0].CoordinateElement().GetNode(0).GetValues();
+    Eigen::VectorXd start = mesh.Elements[0].CoordinateElement().GetNode(0).GetCoordinates();
     Eigen::VectorXd end = start;
 
     unsigned long numNodesTotal = 0;
@@ -118,7 +118,7 @@ SubBoxes<NodePoint>::Domain SetupSubBoxDomain(const NuTo::MeshFem& mesh, int num
 
         for (int iNode = 0; iNode < numNodes; ++iNode)
         {
-            Eigen::VectorXd coords = elementCollection.CoordinateElement().GetNode(iNode).GetValues();
+            Eigen::VectorXd coords = elementCollection.CoordinateElement().GetNode(iNode).GetCoordinates();
             start = start.array().min(coords.array()); // array view (.array()) allows coeffwise operations
             end = end.array().max(coords.array());
         }

--- a/nuto/mechanics/mesh/MeshGmsh.cpp
+++ b/nuto/mechanics/mesh/MeshGmsh.cpp
@@ -387,10 +387,10 @@ const NuTo::InterpolationSimple& CreateElementInterpolation(NuTo::MeshFem& rMesh
     }
 }
 
-std::vector<NuTo::NodeSimple*> GetElementNodes(const std::unordered_map<int, NuTo::NodeSimple*>& nodePtrs,
-                                               const GmshElement& gmshElement)
+std::vector<NuTo::NodeCoordinates*> GetElementNodes(const std::unordered_map<int, NuTo::NodeCoordinates*>& nodePtrs,
+                                                    const GmshElement& gmshElement)
 {
-    std::vector<NuTo::NodeSimple*> elementNodes(gmshElement.nodes.size());
+    std::vector<NuTo::NodeCoordinates*> elementNodes(gmshElement.nodes.size());
     for (unsigned int i = 0; i < elementNodes.size(); ++i)
         elementNodes[i] = nodePtrs.at(gmshElement.nodes[i]);
 
@@ -460,23 +460,23 @@ const NuTo::Group<NuTo::ElementCollectionFem>& NuTo::MeshGmsh::GetPhysicalGroup(
     return physGroupIt->second;
 }
 
-std::unordered_map<int, NuTo::NodeSimple*> NuTo::MeshGmsh::CreateNodes(const GmshFileContent& fileContent)
+std::unordered_map<int, NuTo::NodeCoordinates*> NuTo::MeshGmsh::CreateNodes(const GmshFileContent& fileContent)
 {
-    std::unordered_map<int, NodeSimple*> nodePtrs;
+    std::unordered_map<int, NodeCoordinates*> nodePtrs;
     Eigen::VectorXd coords(fileContent.dimension);
 
     for (const GmshNode& gmshNode : fileContent.nodes)
     {
         for (int i = 0; i < fileContent.dimension; ++i)
             coords[i] = gmshNode.coordinates[i];
-        nodePtrs[gmshNode.id] = &(mMesh.Nodes.Add(coords));
+        nodePtrs[gmshNode.id] = &(mMesh.CoordinateNodes.Add(coords));
     }
     return nodePtrs;
 }
 
 
 void NuTo::MeshGmsh::CreateElements(const GmshFileContent& fileContent,
-                                    const std::unordered_map<int, NuTo::NodeSimple*>& nodePtrs)
+                                    const std::unordered_map<int, NuTo::NodeCoordinates*>& nodePtrs)
 {
     std::map<int, const InterpolationSimple*> interpolationPtrMap;
 

--- a/nuto/mechanics/mesh/MeshGmsh.cpp
+++ b/nuto/mechanics/mesh/MeshGmsh.cpp
@@ -85,7 +85,7 @@ void ExpectNextLineToBe(std::ifstream& rFile, std::string expected)
 // Helper functions (cpp only)
 // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-void CheckJacobian(NuTo::ElementFem& elm)
+void CheckJacobian(NuTo::CoordinateElementFem& elm)
 {
     int n = elm.GetDofDimension();
     NuTo::Jacobian jac(elm.ExtractNodeValues(), elm.GetDerivativeShapeFunctions(Eigen::VectorXd::Zero(n)));
@@ -494,7 +494,7 @@ void NuTo::MeshGmsh::CreateElements(const GmshFileContent& fileContent,
         auto elementNodes = GetElementNodes(nodePtrs, gmshElement);
 
         NuTo::CoordinateElementFem& element = mMesh.Elements.Add({elementNodes, *(interpolationIter->second)});
-        CheckJacobian(element.CoordinateElement());
+        CheckJacobian(element);
         AddElementToPhysicalGroup(fileContent, element, gmshElement.tags[0]);
     }
 }

--- a/nuto/mechanics/mesh/MeshGmsh.cpp
+++ b/nuto/mechanics/mesh/MeshGmsh.cpp
@@ -349,7 +349,7 @@ void ProcessSection(std::ifstream& rFile, GmshFileContent& rFileContent)
 }
 
 
-const NuTo::InterpolationSimple& CreateElementInterpolation(NuTo::MeshFem& rMesh, int gmshType)
+const NuTo::InterpolationSimple& CreateElementInterpolation(NuTo::GeometryMeshFem& rMesh, int gmshType)
 {
     using namespace NuTo;
     switch (gmshType)
@@ -443,7 +443,7 @@ NuTo::MeshGmsh::MeshGmsh(const std::string& fileName)
     ReadGmshFile(fileName);
 }
 
-const NuTo::Group<NuTo::ElementCollectionFem>& NuTo::MeshGmsh::GetPhysicalGroup(std::string physicalName) const
+const NuTo::Group<NuTo::CoordinateElementFem>& NuTo::MeshGmsh::GetPhysicalGroup(std::string physicalName) const
 {
     std::transform(physicalName.begin(), physicalName.end(), physicalName.begin(), ::toupper);
     auto physGroupIt = mNamedPhysicalGroups.find(physicalName);
@@ -452,7 +452,7 @@ const NuTo::Group<NuTo::ElementCollectionFem>& NuTo::MeshGmsh::GetPhysicalGroup(
     return *(physGroupIt->second);
 }
 
-const NuTo::Group<NuTo::ElementCollectionFem>& NuTo::MeshGmsh::GetPhysicalGroup(int physicalGroupId) const
+const NuTo::Group<NuTo::CoordinateElementFem>& NuTo::MeshGmsh::GetPhysicalGroup(int physicalGroupId) const
 {
     auto physGroupIt = mPhysicalGroups.find(physicalGroupId);
     if (physGroupIt == mPhysicalGroups.end())
@@ -493,14 +493,14 @@ void NuTo::MeshGmsh::CreateElements(const GmshFileContent& fileContent,
                             .first;
         auto elementNodes = GetElementNodes(nodePtrs, gmshElement);
 
-        NuTo::ElementCollectionFem& element = mMesh.Elements.Add({{elementNodes, *(interpolationIter->second)}});
+        NuTo::CoordinateElementFem& element = mMesh.Elements.Add({elementNodes, *(interpolationIter->second)});
         CheckJacobian(element.CoordinateElement());
         AddElementToPhysicalGroup(fileContent, element, gmshElement.tags[0]);
     }
 }
 
 
-void NuTo::MeshGmsh::AddElementToPhysicalGroup(const GmshFileContent& fileContent, NuTo::ElementCollectionFem& rElement,
+void NuTo::MeshGmsh::AddElementToPhysicalGroup(const GmshFileContent& fileContent, NuTo::CoordinateElementFem& rElement,
                                                int physicalGroupId)
 {
     // Regarding the map/iterator stuff: https://stackoverflow.com/questions/97050/stdmap-insert-or-stdmap-find
@@ -512,7 +512,7 @@ void NuTo::MeshGmsh::AddElementToPhysicalGroup(const GmshFileContent& fileConten
     {
         // Create new group
         physGroupIt =
-                mPhysicalGroups.emplace_hint(physGroupIt, physicalGroupId, NuTo::Group<ElementCollectionFem>(rElement));
+                mPhysicalGroups.emplace_hint(physGroupIt, physicalGroupId, NuTo::Group<CoordinateElementFem>(rElement));
 
         // Create new named group, if a physicalName is defined
         std::string physicalName = GetPhysicalGroupName(fileContent, physicalGroupId);

--- a/nuto/mechanics/mesh/MeshGmsh.cpp
+++ b/nuto/mechanics/mesh/MeshGmsh.cpp
@@ -88,7 +88,7 @@ void ExpectNextLineToBe(std::ifstream& rFile, std::string expected)
 void CheckJacobian(NuTo::CoordinateElementFem& elm)
 {
     int n = elm.GetDofDimension();
-    NuTo::Jacobian jac(elm.ExtractNodeValues(), elm.GetDerivativeShapeFunctions(Eigen::VectorXd::Zero(n)));
+    NuTo::Jacobian jac(elm.ExtractCoordinates(), elm.GetDerivativeShapeFunctions(Eigen::VectorXd::Zero(n)));
     if (jac.Det() <= 0)
         throw NuTo::Exception(__PRETTY_FUNCTION__, "Negative Jacobian not allowed");
 }

--- a/nuto/mechanics/mesh/MeshGmsh.cpp
+++ b/nuto/mechanics/mesh/MeshGmsh.cpp
@@ -387,10 +387,10 @@ const NuTo::InterpolationSimple& CreateElementInterpolation(NuTo::MeshFem& rMesh
     }
 }
 
-std::vector<NuTo::NodeCoordinates*> GetElementNodes(const std::unordered_map<int, NuTo::NodeCoordinates*>& nodePtrs,
-                                                    const GmshElement& gmshElement)
+std::vector<NuTo::CoordinateNode*> GetElementNodes(const std::unordered_map<int, NuTo::CoordinateNode*>& nodePtrs,
+                                                   const GmshElement& gmshElement)
 {
-    std::vector<NuTo::NodeCoordinates*> elementNodes(gmshElement.nodes.size());
+    std::vector<NuTo::CoordinateNode*> elementNodes(gmshElement.nodes.size());
     for (unsigned int i = 0; i < elementNodes.size(); ++i)
         elementNodes[i] = nodePtrs.at(gmshElement.nodes[i]);
 
@@ -460,9 +460,9 @@ const NuTo::Group<NuTo::ElementCollectionFem>& NuTo::MeshGmsh::GetPhysicalGroup(
     return physGroupIt->second;
 }
 
-std::unordered_map<int, NuTo::NodeCoordinates*> NuTo::MeshGmsh::CreateNodes(const GmshFileContent& fileContent)
+std::unordered_map<int, NuTo::CoordinateNode*> NuTo::MeshGmsh::CreateNodes(const GmshFileContent& fileContent)
 {
-    std::unordered_map<int, NodeCoordinates*> nodePtrs;
+    std::unordered_map<int, CoordinateNode*> nodePtrs;
     Eigen::VectorXd coords(fileContent.dimension);
 
     for (const GmshNode& gmshNode : fileContent.nodes)
@@ -476,7 +476,7 @@ std::unordered_map<int, NuTo::NodeCoordinates*> NuTo::MeshGmsh::CreateNodes(cons
 
 
 void NuTo::MeshGmsh::CreateElements(const GmshFileContent& fileContent,
-                                    const std::unordered_map<int, NuTo::NodeCoordinates*>& nodePtrs)
+                                    const std::unordered_map<int, NuTo::CoordinateNode*>& nodePtrs)
 {
     std::map<int, const InterpolationSimple*> interpolationPtrMap;
 

--- a/nuto/mechanics/mesh/MeshGmsh.h
+++ b/nuto/mechanics/mesh/MeshGmsh.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "nuto/mechanics/mesh/MeshFem.h"
+#include "nuto/mechanics/mesh/GeometryMeshFem.h"
 #include "nuto/base/Group.h"
 #include <string>
 #include <map>
@@ -21,14 +21,14 @@ public:
     MeshGmsh() = delete;
 
     //! @brief copy ctor
-    //! @remark deleted: Member MeshFEM is not copyable
+    //! @remark deleted: Member GeometryMeshFem is not copyable
     MeshGmsh(const MeshGmsh&) = delete;
 
     //! @brief move ctor
     MeshGmsh(MeshGmsh&&) = default;
 
     //! @brief copy assignment operator
-    //! @remark deleted: Member MeshFEM is not copyable
+    //! @remark deleted: Member GeometryMeshFem is not copyable
     MeshGmsh& operator=(const MeshGmsh&) = delete;
 
     //! @brief move assignment operator
@@ -44,16 +44,16 @@ public:
     //! @brief Gets an element collection group associated to the physical name defined in gmsh
     //! @param physicalName Group name (defined in gmsh)
     //! @return Desired element collection group
-    const NuTo::Group<ElementCollectionFem>& GetPhysicalGroup(std::string physicalName) const;
+    const NuTo::Group<CoordinateElementFem>& GetPhysicalGroup(std::string physicalName) const;
 
 
     //! @brief Gets an element collection group associated to the physical ID defined in gmsh
     //! @param physicalGroupId gmsh ID
     //! @return Desired element collection group
-    const NuTo::Group<ElementCollectionFem>& GetPhysicalGroup(int physicalGroupId) const;
+    const NuTo::Group<CoordinateElementFem>& GetPhysicalGroup(int physicalGroupId) const;
 
     //! @brief Gets the MeshFem
-    MeshFem& GetMeshFEM()
+    GeometryMeshFem& GetMeshFEM()
     {
         return mMesh;
     }
@@ -64,7 +64,7 @@ private:
     //! @param fileContent Special structure (see MeshGmsh.cpp) that holds the read file content
     //! @param rElement Current element
     //! @param physicalGroupId Id of the elements physical group
-    void AddElementToPhysicalGroup(const GmshFileContent& fileContent, ElementCollectionFem& rElement,
+    void AddElementToPhysicalGroup(const GmshFileContent& fileContent, CoordinateElementFem& rElement,
                                    int physicalGroupId);
 
     //! @brief Creates all nodes defined in the gmsh file
@@ -81,7 +81,7 @@ private:
     //! @param nodePtrs Collection that holds pointers to all created elements. (See CreateNodes)
     void CreateElements(const GmshFileContent& fileContent, const std::unordered_map<int, CoordinateNode*>& nodePtrs);
 
-    //! @brief Fills the MeshFem member from gmsh file content
+    //! @brief Fills the GeometryMeshFem member from gmsh file content
     //! @param fileContent Special structure (see MeshGmsh.cpp) that holds the read file content
     void CreateMesh(const GmshFileContent& fileContent);
 
@@ -90,12 +90,12 @@ private:
     void ReadGmshFile(const std::string& fileName);
 
     //! @brief Internal mesh
-    MeshFem mMesh;
+    GeometryMeshFem mMesh;
 
     //! @brief Physical groups of the mesh
-    std::map<int, Group<ElementCollectionFem>> mPhysicalGroups;
+    std::map<int, Group<CoordinateElementFem>> mPhysicalGroups;
 
     //! @brief Named physical groups of the mesh
-    std::map<std::string, Group<ElementCollectionFem>*> mNamedPhysicalGroups;
+    std::map<std::string, Group<CoordinateElementFem>*> mNamedPhysicalGroups;
 };
 }

--- a/nuto/mechanics/mesh/MeshGmsh.h
+++ b/nuto/mechanics/mesh/MeshGmsh.h
@@ -74,12 +74,12 @@ private:
     //! set to 2d (or 3d). If at least one node has a z-coordinate the dimension is set to 3d.
     //! @remark The returned collection is used in CreateElements to easily find the nodes connected to a specific gmsh
     //! ID.
-    std::unordered_map<int, NodeCoordinates*> CreateNodes(const GmshFileContent& fileContent);
+    std::unordered_map<int, CoordinateNode*> CreateNodes(const GmshFileContent& fileContent);
 
     //! @brief Creates all elements defined in the gmsh file
     //! @param fileContent Special structure (see MeshGmsh.cpp) that holds the read file content
     //! @param nodePtrs Collection that holds pointers to all created elements. (See CreateNodes)
-    void CreateElements(const GmshFileContent& fileContent, const std::unordered_map<int, NodeCoordinates*>& nodePtrs);
+    void CreateElements(const GmshFileContent& fileContent, const std::unordered_map<int, CoordinateNode*>& nodePtrs);
 
     //! @brief Fills the MeshFem member from gmsh file content
     //! @param fileContent Special structure (see MeshGmsh.cpp) that holds the read file content

--- a/nuto/mechanics/mesh/MeshGmsh.h
+++ b/nuto/mechanics/mesh/MeshGmsh.h
@@ -74,12 +74,12 @@ private:
     //! set to 2d (or 3d). If at least one node has a z-coordinate the dimension is set to 3d.
     //! @remark The returned collection is used in CreateElements to easily find the nodes connected to a specific gmsh
     //! ID.
-    std::unordered_map<int, NodeSimple*> CreateNodes(const GmshFileContent& fileContent);
+    std::unordered_map<int, NodeCoordinates*> CreateNodes(const GmshFileContent& fileContent);
 
     //! @brief Creates all elements defined in the gmsh file
     //! @param fileContent Special structure (see MeshGmsh.cpp) that holds the read file content
     //! @param nodePtrs Collection that holds pointers to all created elements. (See CreateNodes)
-    void CreateElements(const GmshFileContent& fileContent, const std::unordered_map<int, NodeSimple*>& nodePtrs);
+    void CreateElements(const GmshFileContent& fileContent, const std::unordered_map<int, NodeCoordinates*>& nodePtrs);
 
     //! @brief Fills the MeshFem member from gmsh file content
     //! @param fileContent Special structure (see MeshGmsh.cpp) that holds the read file content

--- a/nuto/mechanics/mesh/UnitMeshFem.cpp
+++ b/nuto/mechanics/mesh/UnitMeshFem.cpp
@@ -1,4 +1,5 @@
 #include "nuto/mechanics/mesh/UnitMeshFem.h"
+#include "nuto/mechanics/mesh/GeometryMeshFem.h"
 #include "nuto/mechanics/interpolation/InterpolationTriangleLinear.h"
 #include "nuto/mechanics/interpolation/InterpolationTrussLinear.h"
 #include "nuto/mechanics/interpolation/InterpolationQuadLinear.h"
@@ -7,9 +8,9 @@
 using namespace NuTo;
 
 // anonymous helper functions for mesh creation and transformation
-MeshFem CreateNodes1D(int numX)
+GeometryMeshFem CreateNodes1D(int numX)
 {
-    MeshFem mesh;
+    GeometryMeshFem mesh;
     for (int iX = 0; iX < numX + 1; ++iX)
     {
         const double x = static_cast<double>(iX) / numX;
@@ -19,9 +20,9 @@ MeshFem CreateNodes1D(int numX)
 }
 
 
-MeshFem CreateNodes2D(int numX, int numY)
+GeometryMeshFem CreateNodes2D(int numX, int numY)
 {
-    MeshFem mesh;
+    GeometryMeshFem mesh;
     for (int iY = 0; iY < numY + 1; ++iY)
         for (int iX = 0; iX < numX + 1; ++iX)
         {
@@ -33,23 +34,23 @@ MeshFem CreateNodes2D(int numX, int numY)
 }
 
 
-MeshFem UnitMeshFem::CreateLines(int numX)
+GeometryMeshFem UnitMeshFem::CreateLines(int numX)
 {
-    MeshFem mesh = CreateNodes1D(numX);
+    GeometryMeshFem mesh = CreateNodes1D(numX);
     const auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTrussLinear());
     for (int i = 0; i < numX; ++i)
     {
         auto& nl = mesh.CoordinateNodes[i];
         auto& nr = mesh.CoordinateNodes[i + 1];
-        mesh.Elements.Add({{{nl, nr}, interpolation}});
+        mesh.Elements.Add({{nl, nr}, interpolation});
     }
     return mesh;
 }
 
 
-MeshFem UnitMeshFem::CreateTriangles(int numX, int numY)
+GeometryMeshFem UnitMeshFem::CreateTriangles(int numX, int numY)
 {
-    MeshFem mesh = CreateNodes2D(numX, numY);
+    GeometryMeshFem mesh = CreateNodes2D(numX, numY);
     const auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
     for (int iY = 0; iY < numY; ++iY)
         for (int iX = 0; iX < numX; ++iX)
@@ -58,15 +59,15 @@ MeshFem UnitMeshFem::CreateTriangles(int numX, int numY)
             auto& node1 = mesh.CoordinateNodes[iX + 1 + iY * (numX + 1)];
             auto& node2 = mesh.CoordinateNodes[iX + 1 + (iY + 1) * (numX + 1)];
             auto& node3 = mesh.CoordinateNodes[iX + (iY + 1) * (numX + 1)];
-            mesh.Elements.Add({{{node0, node1, node2}, interpolation}});
-            mesh.Elements.Add({{{node0, node2, node3}, interpolation}});
+            mesh.Elements.Add({{node0, node1, node2}, interpolation});
+            mesh.Elements.Add({{node0, node2, node3}, interpolation});
         }
     return mesh;
 }
 
-MeshFem UnitMeshFem::CreateQuads(int numX, int numY)
+GeometryMeshFem UnitMeshFem::CreateQuads(int numX, int numY)
 {
-    MeshFem mesh = CreateNodes2D(numX, numY);
+    GeometryMeshFem mesh = CreateNodes2D(numX, numY);
     const auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationQuadLinear());
     for (int iY = 0; iY < numY; ++iY)
         for (int iX = 0; iX < numX; ++iX)
@@ -75,14 +76,14 @@ MeshFem UnitMeshFem::CreateQuads(int numX, int numY)
             auto& node1 = mesh.CoordinateNodes[iX + 1 + iY * (numX + 1)];
             auto& node2 = mesh.CoordinateNodes[iX + 1 + (iY + 1) * (numX + 1)];
             auto& node3 = mesh.CoordinateNodes[iX + (iY + 1) * (numX + 1)];
-            mesh.Elements.Add({{{node0, node1, node2, node3}, interpolation}});
+            mesh.Elements.Add({{node0, node1, node2, node3}, interpolation});
         }
     return mesh;
 }
 
-MeshFem UnitMeshFem::CreateBricks(int numX, int numY, int numZ)
+GeometryMeshFem UnitMeshFem::CreateBricks(int numX, int numY, int numZ)
 {
-    MeshFem mesh;
+    GeometryMeshFem mesh;
     int numXe = numX + 1;
     int numYe = numY + 1;
     int numZe = numZ + 1;
@@ -108,13 +109,13 @@ MeshFem UnitMeshFem::CreateBricks(int numX, int numY, int numZ)
                 auto& node5 = mesh.CoordinateNodes[iX + 1 + iY * numXe + (iZ + 1) * numXe * numYe];
                 auto& node6 = mesh.CoordinateNodes[iX + 1 + (iY + 1) * numXe + (iZ + 1) * numXe * numYe];
                 auto& node7 = mesh.CoordinateNodes[iX + (iY + 1) * numXe + (iZ + 1) * numXe * numYe];
-                mesh.Elements.Add({{{node0, node1, node2, node3, node4, node5, node6, node7}, interpolation}});
+                mesh.Elements.Add({{node0, node1, node2, node3, node4, node5, node6, node7}, interpolation});
             }
     return mesh;
 }
 
 
-MeshFem UnitMeshFem::Transform(MeshFem&& oldMesh, std::function<Eigen::VectorXd(Eigen::VectorXd)> f)
+GeometryMeshFem UnitMeshFem::Transform(GeometryMeshFem&& oldMesh, std::function<Eigen::VectorXd(Eigen::VectorXd)> f)
 {
     // Build a group (MeshFem::NodesTotal() selects all coordinate nodes) to avoid duplicates. Otherwise, the
     // transformation is applied multiple times. This is, however, a bit of a bottleneck for big meshes.

--- a/nuto/mechanics/mesh/UnitMeshFem.cpp
+++ b/nuto/mechanics/mesh/UnitMeshFem.cpp
@@ -119,7 +119,7 @@ MeshFem UnitMeshFem::Transform(MeshFem&& oldMesh, std::function<Eigen::VectorXd(
     // Build a group (MeshFem::NodesTotal() selects all coordinate nodes) to avoid duplicates. Otherwise, the
     // transformation is applied multiple times. This is, however, a bit of a bottleneck for big meshes.
     for (auto& node : oldMesh.NodesTotal())
-        node.SetValues(f(node.GetValues()));
+        node.SetCoordinates(f(node.GetCoordinates()));
 
     return std::move(oldMesh);
 }

--- a/nuto/mechanics/mesh/UnitMeshFem.cpp
+++ b/nuto/mechanics/mesh/UnitMeshFem.cpp
@@ -13,7 +13,7 @@ MeshFem CreateNodes1D(int numX)
     for (int iX = 0; iX < numX + 1; ++iX)
     {
         const double x = static_cast<double>(iX) / numX;
-        mesh.Nodes.Add({x});
+        mesh.CoordinateNodes.Add({x});
     }
     return mesh;
 }
@@ -27,7 +27,7 @@ MeshFem CreateNodes2D(int numX, int numY)
         {
             const double x = static_cast<double>(iX) / numX;
             const double y = static_cast<double>(iY) / numY;
-            mesh.Nodes.Add(Eigen::Vector2d(x, y));
+            mesh.CoordinateNodes.Add(Eigen::Vector2d(x, y));
         }
     return mesh;
 }
@@ -39,8 +39,8 @@ MeshFem UnitMeshFem::CreateLines(int numX)
     const auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTrussLinear());
     for (int i = 0; i < numX; ++i)
     {
-        auto& nl = mesh.Nodes[i];
-        auto& nr = mesh.Nodes[i + 1];
+        auto& nl = mesh.CoordinateNodes[i];
+        auto& nr = mesh.CoordinateNodes[i + 1];
         mesh.Elements.Add({{{nl, nr}, interpolation}});
     }
     return mesh;
@@ -54,10 +54,10 @@ MeshFem UnitMeshFem::CreateTriangles(int numX, int numY)
     for (int iY = 0; iY < numY; ++iY)
         for (int iX = 0; iX < numX; ++iX)
         {
-            auto& node0 = mesh.Nodes[iX + iY * (numX + 1)];
-            auto& node1 = mesh.Nodes[iX + 1 + iY * (numX + 1)];
-            auto& node2 = mesh.Nodes[iX + 1 + (iY + 1) * (numX + 1)];
-            auto& node3 = mesh.Nodes[iX + (iY + 1) * (numX + 1)];
+            auto& node0 = mesh.CoordinateNodes[iX + iY * (numX + 1)];
+            auto& node1 = mesh.CoordinateNodes[iX + 1 + iY * (numX + 1)];
+            auto& node2 = mesh.CoordinateNodes[iX + 1 + (iY + 1) * (numX + 1)];
+            auto& node3 = mesh.CoordinateNodes[iX + (iY + 1) * (numX + 1)];
             mesh.Elements.Add({{{node0, node1, node2}, interpolation}});
             mesh.Elements.Add({{{node0, node2, node3}, interpolation}});
         }
@@ -71,10 +71,10 @@ MeshFem UnitMeshFem::CreateQuads(int numX, int numY)
     for (int iY = 0; iY < numY; ++iY)
         for (int iX = 0; iX < numX; ++iX)
         {
-            auto& node0 = mesh.Nodes[iX + iY * (numX + 1)];
-            auto& node1 = mesh.Nodes[iX + 1 + iY * (numX + 1)];
-            auto& node2 = mesh.Nodes[iX + 1 + (iY + 1) * (numX + 1)];
-            auto& node3 = mesh.Nodes[iX + (iY + 1) * (numX + 1)];
+            auto& node0 = mesh.CoordinateNodes[iX + iY * (numX + 1)];
+            auto& node1 = mesh.CoordinateNodes[iX + 1 + iY * (numX + 1)];
+            auto& node2 = mesh.CoordinateNodes[iX + 1 + (iY + 1) * (numX + 1)];
+            auto& node3 = mesh.CoordinateNodes[iX + (iY + 1) * (numX + 1)];
             mesh.Elements.Add({{{node0, node1, node2, node3}, interpolation}});
         }
     return mesh;
@@ -93,21 +93,21 @@ MeshFem UnitMeshFem::CreateBricks(int numX, int numY, int numZ)
                 const double x = static_cast<double>(iX) / numX;
                 const double y = static_cast<double>(iY) / numY;
                 const double z = static_cast<double>(iZ) / numZ;
-                mesh.Nodes.Add(Eigen::Vector3d(x, y, z));
+                mesh.CoordinateNodes.Add(Eigen::Vector3d(x, y, z));
             }
     const auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationBrickLinear());
     for (int iZ = 0; iZ < numZ; ++iZ)
         for (int iY = 0; iY < numY; ++iY)
             for (int iX = 0; iX < numX; ++iX)
             {
-                auto& node0 = mesh.Nodes[iX + iY * numXe + iZ * numXe * numYe];
-                auto& node1 = mesh.Nodes[iX + 1 + iY * numXe + iZ * numXe * numYe];
-                auto& node2 = mesh.Nodes[iX + 1 + (iY + 1) * numXe + iZ * numXe * numYe];
-                auto& node3 = mesh.Nodes[iX + (iY + 1) * numXe + iZ * numXe * numYe];
-                auto& node4 = mesh.Nodes[iX + iY * numXe + (iZ + 1) * numXe * numYe];
-                auto& node5 = mesh.Nodes[iX + 1 + iY * numXe + (iZ + 1) * numXe * numYe];
-                auto& node6 = mesh.Nodes[iX + 1 + (iY + 1) * numXe + (iZ + 1) * numXe * numYe];
-                auto& node7 = mesh.Nodes[iX + (iY + 1) * numXe + (iZ + 1) * numXe * numYe];
+                auto& node0 = mesh.CoordinateNodes[iX + iY * numXe + iZ * numXe * numYe];
+                auto& node1 = mesh.CoordinateNodes[iX + 1 + iY * numXe + iZ * numXe * numYe];
+                auto& node2 = mesh.CoordinateNodes[iX + 1 + (iY + 1) * numXe + iZ * numXe * numYe];
+                auto& node3 = mesh.CoordinateNodes[iX + (iY + 1) * numXe + iZ * numXe * numYe];
+                auto& node4 = mesh.CoordinateNodes[iX + iY * numXe + (iZ + 1) * numXe * numYe];
+                auto& node5 = mesh.CoordinateNodes[iX + 1 + iY * numXe + (iZ + 1) * numXe * numYe];
+                auto& node6 = mesh.CoordinateNodes[iX + 1 + (iY + 1) * numXe + (iZ + 1) * numXe * numYe];
+                auto& node7 = mesh.CoordinateNodes[iX + (iY + 1) * numXe + (iZ + 1) * numXe * numYe];
                 mesh.Elements.Add({{{node0, node1, node2, node3, node4, node5, node6, node7}, interpolation}});
             }
     return mesh;

--- a/nuto/mechanics/mesh/UnitMeshFem.h
+++ b/nuto/mechanics/mesh/UnitMeshFem.h
@@ -1,39 +1,44 @@
 #pragma once
-#include "nuto/mechanics/mesh/MeshFem.h"
+
+#include <functional>
+#include "Eigen/Core"
 
 namespace NuTo
 {
+
+class GeometryMeshFem;
+
 namespace UnitMeshFem
 {
 
 //! @brief creates a 1 dimensional mesh from (0) -- (1) with numX divisions
 //! @param numX number of divisions in x direction
 //! @return created mesh
-MeshFem CreateLines(int numX);
+GeometryMeshFem CreateLines(int numX);
 
 //! @brief creates a triangular mesh from (0,0) -- (1,1) with numX and numY divisions
 //! @param numX number of divisions in x direction
 //! @param numY number of divisions in y direction
 //! @return created mesh
-MeshFem CreateTriangles(int numX, int numY);
+GeometryMeshFem CreateTriangles(int numX, int numY);
 
 //! @brief creates a quad mesh from (0,0) -- (1,1) with numX and numY divisions
 //! @param numX number of divisions in x direction
 //! @param numY number of divisions in y direction
 //! @return created mesh
-MeshFem CreateQuads(int numX, int numY);
+GeometryMeshFem CreateQuads(int numX, int numY);
 
 //! @brief creates a brick mesh from (0,0,0) -- (1,1,1) with numX, numY and numZ divisions
 //! @param numX number of divisions in x direction
 //! @param numY number of divisions in y direction
 //! @param numZ number of divisions in z direction
 //! @return created mesh
-MeshFem CreateBricks(int numX, int numY, int numZ);
+GeometryMeshFem CreateBricks(int numX, int numY, int numZ);
 
 //! @brief transforms a mesh with a given transformation function f
 //! @param oldMesh mesh that is transformed. Call with an xvalue of mesh.
 //! @param f transformation function
-MeshFem Transform(MeshFem&& oldMesh, std::function<Eigen::VectorXd(Eigen::VectorXd)> f);
+GeometryMeshFem Transform(GeometryMeshFem&& oldMesh, std::function<Eigen::VectorXd(Eigen::VectorXd)> f);
 
-} /* UnitMeshFem */
+} /* UnitGeometryMeshFem */
 } /* NuTo */

--- a/nuto/mechanics/nodes/CoordinateNode.h
+++ b/nuto/mechanics/nodes/CoordinateNode.h
@@ -10,12 +10,12 @@ namespace NuTo
 {
 //! @brief Store node values and its dof
 //! @todo fix sized nodes?
-class NodeCoordinates
+class CoordinateNode
 {
 public:
     //! @brief initizalizes the nodes coordintes with `values` and initializes the coordinate numbers to NOT_SET
     //! @param values inititial coordinates
-    NodeCoordinates(Eigen::VectorXd values)
+    CoordinateNode(Eigen::VectorXd values)
         : mCoordinates({values})
         , mCoordinateNumbers(Eigen::VectorXi::Constant(values.rows(), NOT_SET))
     {
@@ -23,7 +23,7 @@ public:
 
     //! @brief initializes a 1D coordinate node with `value` and a coordinate number NOT_SET
     //! @param value initial coordinate value
-    NodeCoordinates(double value)
+    CoordinateNode(double value)
         : mCoordinates(Eigen::VectorXd::Constant(1, value))
         , mCoordinateNumbers(Eigen::VectorXi::Constant(1, NOT_SET))
     {

--- a/nuto/mechanics/nodes/CoordinateNode.h
+++ b/nuto/mechanics/nodes/CoordinateNode.h
@@ -4,7 +4,6 @@
 #include <vector>
 #include <cassert>
 
-#define NOT_SET -1
 
 namespace NuTo
 {
@@ -13,51 +12,36 @@ namespace NuTo
 class CoordinateNode
 {
 public:
-    //! @brief initizalizes the nodes coordintes with `values` and initializes the coordinate numbers to NOT_SET
-    //! @param values inititial coordinates
-    CoordinateNode(Eigen::VectorXd values)
-        : mCoordinates({values})
-        , mCoordinateNumbers(Eigen::VectorXi::Constant(values.rows(), NOT_SET))
+    //! @brief initizalizes the nodes coordintes with the passed values
+    //! @param coordinates : inititial coordinates
+    CoordinateNode(Eigen::VectorXd coordinates)
+        : mCoordinates({coordinates})
     {
     }
 
-    //! @brief initializes a 1D coordinate node with `value` and a coordinate number NOT_SET
-    //! @param value initial coordinate value
-    CoordinateNode(double value)
-        : mCoordinates(Eigen::VectorXd::Constant(1, value))
-        , mCoordinateNumbers(Eigen::VectorXi::Constant(1, NOT_SET))
+    //! @brief initializes a 1D coordinate node with the passed value
+    //! @param coordinate : initial coordinate value
+    CoordinateNode(double coordinate)
+        : mCoordinates(Eigen::VectorXd::Constant(1, coordinate))
     {
     }
 
 
-    const Eigen::VectorXd& GetValues(int instance = 0) const
+    const Eigen::VectorXd& GetCoordinates() const
     {
-        (void)instance; // silence unused parameter warning
         return mCoordinates;
     }
 
-    int GetDofNumber(int component) const
+    void SetCoordinates(Eigen::VectorXd coordinates)
     {
-        assert(component < mCoordinateNumbers.rows());
-        return mCoordinateNumbers[component];
-    }
-
-    void SetValues(Eigen::VectorXd coordinates)
-    {
-        assert(coordinates.size() == mCoordinates.size());
+        assert(coordinates.rows() == mCoordinates.rows());
         mCoordinates = coordinates;
     }
 
-    void SetValue(int component, double value)
+    void SetCoordinate(int component, double value)
     {
-        assert(component < mCoordinateNumbers.rows());
+        assert(component < mCoordinates.rows());
         mCoordinates[component] = value;
-    }
-
-    void SetValueNumber(int component, int coordinateNumber)
-    {
-        assert(component < mCoordinateNumbers.rows());
-        mCoordinateNumbers[component] = coordinateNumber;
     }
 
     int GetNumValues() const
@@ -67,8 +51,6 @@ public:
 
 private:
     Eigen::VectorXd mCoordinates;
-    Eigen::VectorXi mCoordinateNumbers;
 };
 } /* NuTo */
 
-#undef NOT_SET

--- a/nuto/mechanics/nodes/DofNode.h
+++ b/nuto/mechanics/nodes/DofNode.h
@@ -8,14 +8,14 @@ namespace NuTo
 {
 //! @brief Store node values and its dof
 //! @todo fix sized nodes?
-class NodeSimple
+class DofNode
 {
 public:
     //! @brief initizalizes the node values with `values` and initializes the dof numbers to zero
     //! @param values inititial node values
     //! @remark this magic number `-1` indicates an uninitialized state. I was not able to declare a static variable
     //! NOT_SET=-1. Maybe someone else can help.
-    NodeSimple(Eigen::VectorXd values)
+    DofNode(Eigen::VectorXd values)
         : mValues({values})
         , mDofNumbers(Eigen::VectorXi::Constant(values.rows(), -1))
     {
@@ -23,13 +23,13 @@ public:
 
     //! @brief initializes a 1D node with `value` and a dof number 0
     //! @param value initial node value
-    NodeSimple(double value)
+    DofNode(double value)
         : mValues({Eigen::VectorXd::Constant(1, value)})
         , mDofNumbers(Eigen::VectorXi::Zero(1))
     {
     }
 
-    NodeSimple(int dimension, int numInstances)
+    DofNode(int dimension, int numInstances)
         : mValues(numInstances, Eigen::VectorXd::Zero(dimension))
         , mDofNumbers(Eigen::VectorXi::Constant(dimension, -1))
     {

--- a/nuto/mechanics/nodes/NodeCoordinates.h
+++ b/nuto/mechanics/nodes/NodeCoordinates.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <vector>
+#include <cassert>
+
+#define NOT_SET -1
+
+namespace NuTo
+{
+//! @brief Store node values and its dof
+//! @todo fix sized nodes?
+class NodeCoordinates
+{
+public:
+    //! @brief initizalizes the nodes coordintes with `values` and initializes the coordinate numbers to NOT_SET
+    //! @param values inititial coordinates
+    NodeCoordinates(Eigen::VectorXd values)
+        : mCoordinates({values})
+        , mCoordinateNumbers(Eigen::VectorXi::Constant(values.rows(), NOT_SET))
+    {
+    }
+
+    //! @brief initializes a 1D coordinate node with `value` and a coordinate number NOT_SET
+    //! @param value initial coordinate value
+    NodeCoordinates(double value)
+        : mCoordinates(Eigen::VectorXd::Constant(1, value))
+        , mCoordinateNumbers(Eigen::VectorXi::Constant(1, NOT_SET))
+    {
+    }
+
+
+    const Eigen::VectorXd& GetCoordinates() const
+    {
+        return mCoordinates;
+    }
+
+    int GetCoordinateNumber(int component) const
+    {
+        assert(component < mCoordinateNumbers.rows());
+        return mCoordinateNumbers[component];
+    }
+
+    void SetCoordinates(Eigen::VectorXd coordinates)
+    {
+        assert(coordinates.size() == mCoordinates.size());
+        mCoordinates = coordinates;
+    }
+
+    void SetCoordinate(int component, double value)
+    {
+        assert(component < mCoordinateNumbers.rows());
+        mCoordinates[component] = value;
+    }
+
+    void SetCoordinateNumber(int component, int coordinateNumber)
+    {
+        assert(component < mCoordinateNumbers.rows());
+        mCoordinateNumbers[component] = coordinateNumber;
+    }
+
+    int GetNumCoordinates() const
+    {
+        return mCoordinates.rows();
+    }
+
+private:
+    Eigen::VectorXd mCoordinates;
+    Eigen::VectorXi mCoordinateNumbers;
+};
+} /* NuTo */
+
+#undef NOT_SET

--- a/nuto/mechanics/nodes/NodeCoordinates.h
+++ b/nuto/mechanics/nodes/NodeCoordinates.h
@@ -30,36 +30,37 @@ public:
     }
 
 
-    const Eigen::VectorXd& GetCoordinates() const
+    const Eigen::VectorXd& GetValues(int instance = 0) const
     {
+        (void)instance; // silence unused parameter warning
         return mCoordinates;
     }
 
-    int GetCoordinateNumber(int component) const
+    int GetDofNumber(int component) const
     {
         assert(component < mCoordinateNumbers.rows());
         return mCoordinateNumbers[component];
     }
 
-    void SetCoordinates(Eigen::VectorXd coordinates)
+    void SetValues(Eigen::VectorXd coordinates)
     {
         assert(coordinates.size() == mCoordinates.size());
         mCoordinates = coordinates;
     }
 
-    void SetCoordinate(int component, double value)
+    void SetValue(int component, double value)
     {
         assert(component < mCoordinateNumbers.rows());
         mCoordinates[component] = value;
     }
 
-    void SetCoordinateNumber(int component, int coordinateNumber)
+    void SetValueNumber(int component, int coordinateNumber)
     {
         assert(component < mCoordinateNumbers.rows());
         mCoordinateNumbers[component] = coordinateNumber;
     }
 
-    int GetNumCoordinates() const
+    int GetNumValues() const
     {
         return mCoordinates.rows();
     }

--- a/nuto/mechanics/tools/AdaptiveSolve.cpp
+++ b/nuto/mechanics/tools/AdaptiveSolve.cpp
@@ -20,6 +20,7 @@ void AdaptiveSolve::Solve(double tEnd, double tStart)
     Timer timer(__PRETTY_FUNCTION__, true, Log::Info);
     double t = tStart;
     Log::Info << rang::fg::blue << "Starting adaptive solve from t = " << t << rang::style::reset << '\n';
+
     int iStep = 0;
 
     mPostProcess(t);

--- a/nuto/mechanics/tools/NodalValueMerger.cpp
+++ b/nuto/mechanics/tools/NodalValueMerger.cpp
@@ -7,7 +7,7 @@ NodalValueMerger::NodalValueMerger(MeshFem* rMesh)
 {
 }
 
-Group<NodeSimple>& NodalValueMerger::Nodes(DofType dof)
+Group<DofNode>& NodalValueMerger::Nodes(DofType dof)
 {
     if (!mNodes.Has(dof))
         mNodes[dof] = mMesh.NodesTotal(dof);

--- a/nuto/mechanics/tools/NodalValueMerger.h
+++ b/nuto/mechanics/tools/NodalValueMerger.h
@@ -25,10 +25,10 @@ public:
     //! node group memoizer
     //! @param dof dof type
     //! @return a memoized node group
-    Group<NodeSimple>& Nodes(DofType dof);
+    Group<DofNode>& Nodes(DofType dof);
 
 private:
     MeshFem& mMesh;
-    DofContainer<Group<NodeSimple>> mNodes;
+    DofContainer<Group<DofNode>> mNodes;
 };
 } /* NuTo */

--- a/test/mechanics/cell/Cell.cpp
+++ b/test/mechanics/cell/Cell.cpp
@@ -2,6 +2,7 @@
 #include <fakeit.hpp>
 
 #include "nuto/math/shapes/Triangle.h"
+#include "nuto/math/shapes/Line.h"
 
 #include "nuto/mechanics/cell/Cell.h"
 #include "nuto/mechanics/elements/ElementCollection.h"

--- a/test/mechanics/cell/Cell.cpp
+++ b/test/mechanics/cell/Cell.cpp
@@ -51,6 +51,7 @@ BOOST_AUTO_TEST_CASE(CellLetsSee)
     auto quad = NuTo::Quadrilateral();
     fakeit::When(Method(intType, GetShape)).AlwaysReturn(quad);
 
+
     NuTo::Laws::LinearElastic<2> law(E, 0.0, NuTo::ePlaneState::PLANE_STRAIN);
     using namespace NuTo::Integrands;
     MomentumBalance<2> integrand({dofDispl}, law);
@@ -66,6 +67,12 @@ BOOST_AUTO_TEST_CASE(CellLetsSee)
 
     NuTo::Cell cell(elements, intType.get(), 1337);
     BOOST_CHECK(cell.Id() == 1337);
+
+    // Test incompatible shape type
+    fakeit::Mock<NuTo::IntegrationTypeBase> intTypeWrong;
+    NuTo::Line line;
+    Method(intTypeWrong, GetShape) = line;
+    BOOST_CHECK_THROW(NuTo::Cell(elements, intTypeWrong.get(), 1337), NuTo::Exception);
 
     BoostUnitTest::CheckVector(cell.Integrate(GradientF)[dofDispl], Eigen::VectorXd::Zero(8), 8);
 

--- a/test/mechanics/cell/Cell.cpp
+++ b/test/mechanics/cell/Cell.cpp
@@ -47,6 +47,7 @@ BOOST_AUTO_TEST_CASE(CellLetsSee)
     fakeit::When(Method(intType, GetLocalIntegrationPointCoordinates).Using(1)).AlwaysReturn(Eigen::Vector2d({a, -a}));
     fakeit::When(Method(intType, GetLocalIntegrationPointCoordinates).Using(2)).AlwaysReturn(Eigen::Vector2d({a, a}));
     fakeit::When(Method(intType, GetLocalIntegrationPointCoordinates).Using(3)).AlwaysReturn(Eigen::Vector2d({-a, a}));
+
     auto quad = NuTo::Quadrilateral();
     fakeit::When(Method(intType, GetShape)).AlwaysReturn(quad);
 

--- a/test/mechanics/cell/Cell.cpp
+++ b/test/mechanics/cell/Cell.cpp
@@ -22,17 +22,17 @@ BOOST_AUTO_TEST_CASE(CellLetsSee)
     const double E = 6174;
 
     NuTo::InterpolationQuadLinear interpolationCoordinates;
-    NuTo::NodeCoordinates nCoord0(Eigen::Vector2d({0, 0}));
-    NuTo::NodeCoordinates nCoord1(Eigen::Vector2d({lx, 0}));
-    NuTo::NodeCoordinates nCoord2(Eigen::Vector2d({lx, ly}));
-    NuTo::NodeCoordinates nCoord3(Eigen::Vector2d({0, ly}));
+    NuTo::CoordinateNode nCoord0(Eigen::Vector2d({0, 0}));
+    NuTo::CoordinateNode nCoord1(Eigen::Vector2d({lx, 0}));
+    NuTo::CoordinateNode nCoord2(Eigen::Vector2d({lx, ly}));
+    NuTo::CoordinateNode nCoord3(Eigen::Vector2d({0, ly}));
     NuTo::CoordinateElementFem coordinateElement({nCoord0, nCoord1, nCoord2, nCoord3}, interpolationCoordinates);
 
     NuTo::InterpolationQuadLinear interpolationDisplacements;
-    NuTo::NodeSimple nDispl0(Eigen::Vector2d({0, 0}));
-    NuTo::NodeSimple nDispl1(Eigen::Vector2d({0, 0}));
-    NuTo::NodeSimple nDispl2(Eigen::Vector2d({0, 0}));
-    NuTo::NodeSimple nDispl3(Eigen::Vector2d({0, 0}));
+    NuTo::DofNode nDispl0(Eigen::Vector2d({0, 0}));
+    NuTo::DofNode nDispl1(Eigen::Vector2d({0, 0}));
+    NuTo::DofNode nDispl2(Eigen::Vector2d({0, 0}));
+    NuTo::DofNode nDispl3(Eigen::Vector2d({0, 0}));
     NuTo::DofElementFem displacementElement({nDispl0, nDispl1, nDispl2, nDispl3}, interpolationDisplacements);
 
     NuTo::ElementCollectionFem elements(coordinateElement);

--- a/test/mechanics/cell/Cell.cpp
+++ b/test/mechanics/cell/Cell.cpp
@@ -22,11 +22,11 @@ BOOST_AUTO_TEST_CASE(CellLetsSee)
     const double E = 6174;
 
     NuTo::InterpolationQuadLinear interpolationCoordinates;
-    NuTo::NodeSimple nCoord0(Eigen::Vector2d({0, 0}));
-    NuTo::NodeSimple nCoord1(Eigen::Vector2d({lx, 0}));
-    NuTo::NodeSimple nCoord2(Eigen::Vector2d({lx, ly}));
-    NuTo::NodeSimple nCoord3(Eigen::Vector2d({0, ly}));
-    NuTo::DofElementFem coordinateElement({nCoord0, nCoord1, nCoord2, nCoord3}, interpolationCoordinates);
+    NuTo::NodeCoordinates nCoord0(Eigen::Vector2d({0, 0}));
+    NuTo::NodeCoordinates nCoord1(Eigen::Vector2d({lx, 0}));
+    NuTo::NodeCoordinates nCoord2(Eigen::Vector2d({lx, ly}));
+    NuTo::NodeCoordinates nCoord3(Eigen::Vector2d({0, ly}));
+    NuTo::CoordinateElementFem coordinateElement({nCoord0, nCoord1, nCoord2, nCoord3}, interpolationCoordinates);
 
     NuTo::InterpolationQuadLinear interpolationDisplacements;
     NuTo::NodeSimple nDispl0(Eigen::Vector2d({0, 0}));

--- a/test/mechanics/cell/Cell.cpp
+++ b/test/mechanics/cell/Cell.cpp
@@ -26,14 +26,14 @@ BOOST_AUTO_TEST_CASE(CellLetsSee)
     NuTo::NodeSimple nCoord1(Eigen::Vector2d({lx, 0}));
     NuTo::NodeSimple nCoord2(Eigen::Vector2d({lx, ly}));
     NuTo::NodeSimple nCoord3(Eigen::Vector2d({0, ly}));
-    NuTo::ElementFem coordinateElement({nCoord0, nCoord1, nCoord2, nCoord3}, interpolationCoordinates);
+    NuTo::DofElementFem coordinateElement({nCoord0, nCoord1, nCoord2, nCoord3}, interpolationCoordinates);
 
     NuTo::InterpolationQuadLinear interpolationDisplacements;
     NuTo::NodeSimple nDispl0(Eigen::Vector2d({0, 0}));
     NuTo::NodeSimple nDispl1(Eigen::Vector2d({0, 0}));
     NuTo::NodeSimple nDispl2(Eigen::Vector2d({0, 0}));
     NuTo::NodeSimple nDispl3(Eigen::Vector2d({0, 0}));
-    NuTo::ElementFem displacementElement({nDispl0, nDispl1, nDispl2, nDispl3}, interpolationDisplacements);
+    NuTo::DofElementFem displacementElement({nDispl0, nDispl1, nDispl2, nDispl3}, interpolationDisplacements);
 
     NuTo::ElementCollectionFem elements(coordinateElement);
     NuTo::DofType dofDispl("Displacements", 2);

--- a/test/mechanics/cell/CellData.cpp
+++ b/test/mechanics/cell/CellData.cpp
@@ -5,7 +5,7 @@
 BOOST_AUTO_TEST_CASE(CacheNodeValues)
 {
     constexpr int cellID = 1337;
-    fakeit::Mock<NuTo::ElementInterface> mockElement;
+    fakeit::Mock<NuTo::DofElementInterface> mockElement;
     Method(mockElement, ExtractNodeValues).Using(0) = Eigen::Vector2d({42, 6174});
     Method(mockElement, ExtractNodeValues).Using(1) = Eigen::Vector2d({.42, .6174});
 

--- a/test/mechanics/cell/CellIpData.cpp
+++ b/test/mechanics/cell/CellIpData.cpp
@@ -9,13 +9,18 @@ BOOST_AUTO_TEST_CASE(CellIpDataMemoizationB)
     Eigen::VectorXd nodalValues(6);
     nodalValues << 0, 0, 1, 0, 0, 1;
 
-    fakeit::Mock<NuTo::ElementInterface> mockElement;
+    fakeit::Mock<NuTo::CoordinateElementInterface> mockElement;
     Method(mockElement, GetDerivativeShapeFunctions) = dNdXi;
     Method(mockElement, GetNMatrix) = Eigen::MatrixXd::Ones(2, 6);
-    Method(mockElement, ExtractNodeValues) = nodalValues;
+    Method(mockElement, ExtractCoordinates) = nodalValues;
+
+    fakeit::Mock<NuTo::DofElementInterface> mockDofElement;
+    Method(mockDofElement, ExtractNodeValues) = nodalValues;
+    Method(mockDofElement, GetDerivativeShapeFunctions) = dNdXi;
+    Method(mockDofElement, GetNMatrix) = Eigen::MatrixXd::Ones(2, 6);
 
     fakeit::Mock<NuTo::ElementCollection> elements;
-    Method(elements, DofElement) = mockElement.get();
+    Method(elements, DofElement) = mockDofElement.get();
     Method(elements, CoordinateElement) = mockElement.get();
 
     fakeit::Mock<NuTo::Nabla::Interface> mockGradientOperator;

--- a/test/mechanics/constraints/ConstraintCompanion.cpp
+++ b/test/mechanics/constraints/ConstraintCompanion.cpp
@@ -74,9 +74,9 @@ public:
     }
 
     std::function<double(double)> sinFunction = [](double time) { return std::sin(time); };
-    Group<NodeSimple> nodes;
-    NodeSimple node1 = NodeSimple(Eigen::VectorXd::Ones(3));
-    NodeSimple node2 = NodeSimple(Eigen::VectorXd::Ones(3));
+    Group<DofNode> nodes;
+    DofNode node1 = DofNode(Eigen::VectorXd::Ones(3));
+    DofNode node2 = DofNode(Eigen::VectorXd::Ones(3));
     double reciprocalNorm = 1.0 / std::sqrt(3.0);
 };
 
@@ -195,8 +195,8 @@ BOOST_FIXTURE_TEST_CASE(Value_test, Helpers)
     BOOST_CHECK_THROW(Constraint::Value(node1, 42.), Exception);
     BOOST_CHECK_THROW(Constraint::Value(node1, sinFunction), Exception);
 
-    node1 = NodeSimple(Eigen::VectorXd::Ones(1));
-    node2 = NodeSimple(Eigen::VectorXd::Ones(1));
+    node1 = DofNode(Eigen::VectorXd::Ones(1));
+    node2 = DofNode(Eigen::VectorXd::Ones(1));
 
 
     // with constant RHS

--- a/test/mechanics/constraints/Constraints.cpp
+++ b/test/mechanics/constraints/Constraints.cpp
@@ -54,6 +54,7 @@ BOOST_AUTO_TEST_CASE(ConstraintCMatrixInteracting)
     DofNode node2(0);
     DofNode node3(0);
     DofNode node4(0);
+    DofNode node5(0);
 
     /*
      *     n0 ---- n1 ---- n2 ---- n3 --- n4 --- n5

--- a/test/mechanics/constraints/Constraints.cpp
+++ b/test/mechanics/constraints/Constraints.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include "BoostUnitTest.h"
 #include "nuto/base/Exception.h"
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 #include "nuto/mechanics/constraints/Constraints.h"
 
 using namespace NuTo;
@@ -12,7 +12,7 @@ auto rhs = [](double) { return 42; };
 
 BOOST_AUTO_TEST_CASE(ConstraintUnnumbered)
 {
-    NodeSimple node(Eigen::Vector2d::Zero());
+    DofNode node(Eigen::Vector2d::Zero());
     Constraints c;
     c.Add(dof, Equation(node, 0, rhs));
     // the dofs are not numbered.
@@ -21,10 +21,10 @@ BOOST_AUTO_TEST_CASE(ConstraintUnnumbered)
 
 BOOST_AUTO_TEST_CASE(ConstraintCMatrix)
 {
-    NodeSimple node0(0);
-    NodeSimple node1(0);
-    NodeSimple node2(0);
-    NodeSimple node3(0);
+    DofNode node0(0);
+    DofNode node1(0);
+    DofNode node2(0);
+    DofNode node3(0);
 
     /*
      *  n0 ---- n1 ---- n2 ---- n3
@@ -49,12 +49,11 @@ BOOST_AUTO_TEST_CASE(ConstraintCMatrix)
 
 BOOST_AUTO_TEST_CASE(ConstraintCMatrixInteracting)
 {
-    NodeSimple node0(0);
-    NodeSimple node1(0);
-    NodeSimple node2(0);
-    NodeSimple node3(0);
-    NodeSimple node4(0);
-    NodeSimple node5(0);
+    DofNode node0(0);
+    DofNode node1(0);
+    DofNode node2(0);
+    DofNode node3(0);
+    DofNode node4(0);
 
     /*
      *     n0 ---- n1 ---- n2 ---- n3 --- n4 --- n5
@@ -101,7 +100,7 @@ BOOST_AUTO_TEST_CASE(ConstraintCMatrixInteracting)
 BOOST_AUTO_TEST_CASE(ConstraintRhs)
 {
     Constraints c;
-    NodeSimple dummyNode(Eigen::Vector2d::Zero());
+    DofNode dummyNode(Eigen::Vector2d::Zero());
     c.Add(dof, Equation(dummyNode, 0, [](double) { return 1; }));
     c.Add(dof, Equation(dummyNode, 1, [](double time) { return time * 42; }));
 
@@ -112,7 +111,7 @@ BOOST_AUTO_TEST_CASE(ConstraintRhs)
 
 BOOST_AUTO_TEST_CASE(ConstraintUnavailableComponent)
 {
-    NodeSimple dummyNode(Eigen::Vector2d::Zero()); // node with two components
+    DofNode dummyNode(Eigen::Vector2d::Zero()); // node with two components
     BOOST_CHECK_THROW(Term(dummyNode, 42, 1), Exception);
     BOOST_CHECK_THROW(Term(dummyNode, 2, 1), Exception);
     BOOST_CHECK_NO_THROW(Term(dummyNode, 1, 1));
@@ -121,7 +120,7 @@ BOOST_AUTO_TEST_CASE(ConstraintUnavailableComponent)
 BOOST_AUTO_TEST_CASE(ConstraintDoubleConstrained)
 {
     Constraints constraints;
-    NodeSimple node(Eigen::Vector2d::Zero());
+    DofNode node(Eigen::Vector2d::Zero());
 
     constraints.Add(dof, {node, 0, rhs});
     BOOST_CHECK_THROW(constraints.Add(dof, {node, 0, rhs}), Exception);
@@ -130,7 +129,7 @@ BOOST_AUTO_TEST_CASE(ConstraintDoubleConstrained)
 BOOST_AUTO_TEST_CASE(ConstraintTwoDependentDofsInOneEquation)
 {
     Constraint::Constraints constraints;
-    NodeSimple node(Eigen::Vector2d::Zero());
+    DofNode node(Eigen::Vector2d::Zero());
 
     constraints.Add(dof, {node, 0, rhs}); // node.dof0 * 1.0 = rhs
 

--- a/test/mechanics/dofs/DofNumbering.cpp
+++ b/test/mechanics/dofs/DofNumbering.cpp
@@ -16,13 +16,13 @@ const DofType d("stuff", 2);
 BOOST_AUTO_TEST_CASE(DofNumberingTest)
 {
     // Add three 2d nodes, one of them constrained in x and y.
-    NodeSimple nodeUnconstrained0(Eigen::Vector2d::Zero());
-    NodeSimple nodeUnconstrained1(Eigen::Vector2d::Zero());
-    NodeSimple nodeConstrained(Eigen::Vector2d::Zero());
+    DofNode nodeUnconstrained0(Eigen::Vector2d::Zero());
+    DofNode nodeUnconstrained1(Eigen::Vector2d::Zero());
+    DofNode nodeConstrained(Eigen::Vector2d::Zero());
 
     Constraint::Constraints constraints;
 
-    Group<NodeSimple> group({nodeConstrained, nodeUnconstrained0, nodeUnconstrained1});
+    Group<DofNode> group({nodeConstrained, nodeUnconstrained0, nodeUnconstrained1});
 
     constraints.Add(d, {nodeConstrained, 1, rhs}); // 1st equation for component 1 --> expected number 4
     constraints.Add(d, {nodeConstrained, 0, rhs}); // 2nd equation for component 0 --> expected number 5
@@ -40,8 +40,8 @@ BOOST_AUTO_TEST_CASE(DofNumberingTest)
 
 BOOST_AUTO_TEST_CASE(InvalidDofTypes)
 {
-    NodeSimple n0(0);
-    NodeSimple n1(1);
+    DofNode n0(0);
+    DofNode n1(1);
 
     Constraint::Constraints constraints;
     constraints.Add(d, {n0, 0, rhs});
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(InvalidDofTypes)
 
 BOOST_AUTO_TEST_CASE(Extract)
 {
-    NodeSimple n0(Eigen::Vector2d::Zero());
+    DofNode n0(Eigen::Vector2d::Zero());
     n0.SetDofNumber(0, 42);
     n0.SetDofNumber(1, 4);
 

--- a/test/mechanics/elements/CMakeLists.txt
+++ b/test/mechanics/elements/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_unit_test(ElementIga)
-add_unit_test(ElementFem
+add_unit_test(DofElementFem
+    mechanics/interpolation/InterpolationTriangleLinear.cpp
+    )
+add_unit_test(CoordinateElementFem
     mechanics/interpolation/InterpolationTriangleLinear.cpp
     )
 add_unit_test(ElementCollection

--- a/test/mechanics/elements/CoordinateElementFem.cpp
+++ b/test/mechanics/elements/CoordinateElementFem.cpp
@@ -24,13 +24,13 @@ NuTo::CoordinateElementFem TestElement()
 
 BOOST_AUTO_TEST_CASE(ExtractNodeValues)
 {
-    Eigen::VectorXd nodeValues = TestElement().ExtractNodeValues();
+    Eigen::VectorXd nodeValues = TestElement().ExtractCoordinates();
     BoostUnitTest::CheckVector(nodeValues, std::vector<double>{1, 1, 5, 1, 1, 7}, 6);
 }
 
 BOOST_AUTO_TEST_CASE(Interpolation)
 {
-    Eigen::VectorXd nodeValues = TestElement().ExtractNodeValues();
+    Eigen::VectorXd nodeValues = TestElement().ExtractCoordinates();
     Eigen::MatrixXd N = TestElement().GetNMatrix(Eigen::Vector2d(0.5, 0.5));
     Eigen::Vector2d interpolatedValues = N * nodeValues;
     BoostUnitTest::CheckVector(interpolatedValues, std::vector<double>{3, 4}, 2);

--- a/test/mechanics/elements/CoordinateElementFem.cpp
+++ b/test/mechanics/elements/CoordinateElementFem.cpp
@@ -1,0 +1,37 @@
+#include "BoostUnitTest.h"
+#include <type_traits>
+
+#include "nuto/mechanics/elements/CoordinateElementFem.h"
+#include "nuto/mechanics/interpolation/InterpolationTriangleLinear.h"
+
+
+BOOST_AUTO_TEST_CASE(ElementCopyMove)
+{
+    BOOST_CHECK(std::is_copy_constructible<NuTo::CoordinateElementFem>::value);
+    BOOST_CHECK(std::is_move_constructible<NuTo::CoordinateElementFem>::value);
+}
+
+
+NuTo::CoordinateNode n0 = NuTo::CoordinateNode(Eigen::Vector2d({1, 1}));
+NuTo::CoordinateNode n1 = NuTo::CoordinateNode(Eigen::Vector2d({5, 1}));
+NuTo::CoordinateNode n2 = NuTo::CoordinateNode(Eigen::Vector2d({1, 7}));
+NuTo::InterpolationTriangleLinear interpolation;
+
+NuTo::CoordinateElementFem TestElement()
+{
+    return NuTo::CoordinateElementFem({n0, n1, n2}, interpolation);
+}
+
+BOOST_AUTO_TEST_CASE(ExtractNodeValues)
+{
+    Eigen::VectorXd nodeValues = TestElement().ExtractNodeValues();
+    BoostUnitTest::CheckVector(nodeValues, std::vector<double>{1, 1, 5, 1, 1, 7}, 6);
+}
+
+BOOST_AUTO_TEST_CASE(Interpolation)
+{
+    Eigen::VectorXd nodeValues = TestElement().ExtractNodeValues();
+    Eigen::MatrixXd N = TestElement().GetNMatrix(Eigen::Vector2d(0.5, 0.5));
+    Eigen::Vector2d interpolatedValues = N * nodeValues;
+    BoostUnitTest::CheckVector(interpolatedValues, std::vector<double>{3, 4}, 2);
+}

--- a/test/mechanics/elements/DofElementFem.cpp
+++ b/test/mechanics/elements/DofElementFem.cpp
@@ -1,7 +1,7 @@
 #include "BoostUnitTest.h"
 #include <type_traits>
 
-#include "nuto/mechanics/elements/ElementFem.h"
+#include "nuto/mechanics/elements/DofElementFem.h"
 #include "nuto/mechanics/interpolation/InterpolationTriangleLinear.h"
 
 

--- a/test/mechanics/elements/ElementCollection.cpp
+++ b/test/mechanics/elements/ElementCollection.cpp
@@ -11,7 +11,7 @@ BOOST_AUTO_TEST_CASE(ElementCollectionAccess)
     NuTo::InterpolationTriangleLinear interpolation;
 
 
-    NuTo::ElementCollectionFem elements(NuTo::ElementFem({n0, n1, n2}, interpolation));
+    NuTo::ElementCollectionFem elements(NuTo::DofElementFem({n0, n1, n2}, interpolation));
     BOOST_CHECK_NO_THROW(elements.CoordinateElement().Interpolation());
 
     NuTo::ElementCollection& cellElements = elements;

--- a/test/mechanics/elements/ElementCollection.cpp
+++ b/test/mechanics/elements/ElementCollection.cpp
@@ -5,9 +5,9 @@
 
 BOOST_AUTO_TEST_CASE(ElementCollectionAccess)
 {
-    NuTo::NodeCoordinates n0(Eigen::Vector2d(0, 0));
-    NuTo::NodeCoordinates n1(Eigen::Vector2d(0, 0));
-    NuTo::NodeCoordinates n2(Eigen::Vector2d(0, 0));
+    NuTo::CoordinateNode n0(Eigen::Vector2d(0, 0));
+    NuTo::CoordinateNode n1(Eigen::Vector2d(0, 0));
+    NuTo::CoordinateNode n2(Eigen::Vector2d(0, 0));
     NuTo::InterpolationTriangleLinear interpolation;
 
 

--- a/test/mechanics/elements/ElementCollection.cpp
+++ b/test/mechanics/elements/ElementCollection.cpp
@@ -11,7 +11,8 @@ BOOST_AUTO_TEST_CASE(ElementCollectionAccess)
     NuTo::InterpolationTriangleLinear interpolation;
 
 
-    NuTo::ElementCollectionFem elements(NuTo::CoordinateElementFem({n0, n1, n2}, interpolation));
+    NuTo::CoordinateElementFem cElm({n0, n1, n2}, interpolation);
+    NuTo::ElementCollectionFem elements(cElm);
     BOOST_CHECK_NO_THROW(elements.CoordinateElement().Interpolation());
 
     NuTo::ElementCollection& cellElements = elements;

--- a/test/mechanics/elements/ElementCollection.cpp
+++ b/test/mechanics/elements/ElementCollection.cpp
@@ -5,13 +5,13 @@
 
 BOOST_AUTO_TEST_CASE(ElementCollectionAccess)
 {
-    NuTo::NodeSimple n0(Eigen::Vector2d(0, 0));
-    NuTo::NodeSimple n1(Eigen::Vector2d(0, 0));
-    NuTo::NodeSimple n2(Eigen::Vector2d(0, 0));
+    NuTo::NodeCoordinates n0(Eigen::Vector2d(0, 0));
+    NuTo::NodeCoordinates n1(Eigen::Vector2d(0, 0));
+    NuTo::NodeCoordinates n2(Eigen::Vector2d(0, 0));
     NuTo::InterpolationTriangleLinear interpolation;
 
 
-    NuTo::ElementCollectionFem elements(NuTo::DofElementFem({n0, n1, n2}, interpolation));
+    NuTo::ElementCollectionFem elements(NuTo::CoordinateElementFem({n0, n1, n2}, interpolation));
     BOOST_CHECK_NO_THROW(elements.CoordinateElement().Interpolation());
 
     NuTo::ElementCollection& cellElements = elements;

--- a/test/mechanics/elements/ElementFem.cpp
+++ b/test/mechanics/elements/ElementFem.cpp
@@ -12,9 +12,9 @@ BOOST_AUTO_TEST_CASE(ElementCopyMove)
 }
 
 
-NuTo::NodeSimple n0 = NuTo::NodeSimple(Eigen::Vector2d({1, 1}));
-NuTo::NodeSimple n1 = NuTo::NodeSimple(Eigen::Vector2d({5, 1}));
-NuTo::NodeSimple n2 = NuTo::NodeSimple(Eigen::Vector2d({1, 7}));
+NuTo::DofNode n0 = NuTo::DofNode(Eigen::Vector2d({1, 1}));
+NuTo::DofNode n1 = NuTo::DofNode(Eigen::Vector2d({5, 1}));
+NuTo::DofNode n2 = NuTo::DofNode(Eigen::Vector2d({1, 7}));
 NuTo::InterpolationTriangleLinear interpolation;
 
 NuTo::DofElementFem TestElement()
@@ -38,9 +38,9 @@ BOOST_AUTO_TEST_CASE(Interpolation)
 
 BOOST_AUTO_TEST_CASE(ExtractNodeValueInstances)
 {
-    NuTo::NodeSimple node0(1, 2);
-    NuTo::NodeSimple node1(1, 2);
-    NuTo::NodeSimple node2(1, 2);
+    NuTo::DofNode node0(1, 2);
+    NuTo::DofNode node1(1, 2);
+    NuTo::DofNode node2(1, 2);
 
     node0.SetValue(0, 42., 1);
     node1.SetValue(0, 43., 1);

--- a/test/mechanics/elements/ElementFem.cpp
+++ b/test/mechanics/elements/ElementFem.cpp
@@ -7,8 +7,8 @@
 
 BOOST_AUTO_TEST_CASE(ElementCopyMove)
 {
-    BOOST_CHECK(std::is_copy_constructible<NuTo::ElementFem>::value);
-    BOOST_CHECK(std::is_move_constructible<NuTo::ElementFem>::value);
+    BOOST_CHECK(std::is_copy_constructible<NuTo::DofElementFem>::value);
+    BOOST_CHECK(std::is_move_constructible<NuTo::DofElementFem>::value);
 }
 
 
@@ -17,9 +17,9 @@ NuTo::NodeSimple n1 = NuTo::NodeSimple(Eigen::Vector2d({5, 1}));
 NuTo::NodeSimple n2 = NuTo::NodeSimple(Eigen::Vector2d({1, 7}));
 NuTo::InterpolationTriangleLinear interpolation;
 
-NuTo::ElementFem TestElement()
+NuTo::DofElementFem TestElement()
 {
-    return NuTo::ElementFem({n0, n1, n2}, interpolation);
+    return NuTo::DofElementFem({n0, n1, n2}, interpolation);
 }
 
 BOOST_AUTO_TEST_CASE(ExtractNodeValues)
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(ExtractNodeValueInstances)
     node1.SetValue(0, 43., 1);
     node2.SetValue(0, 44., 1);
 
-    NuTo::ElementFem e({node0, node1, node2}, interpolation);
+    NuTo::DofElementFem e({node0, node1, node2}, interpolation);
     BoostUnitTest::CheckEigenMatrix(e.ExtractNodeValues(), Eigen::Vector3d::Zero());
     BoostUnitTest::CheckEigenMatrix(e.ExtractNodeValues(1), Eigen::Vector3d(42, 43, 44));
 }

--- a/test/mechanics/elements/ElementIga.cpp
+++ b/test/mechanics/elements/ElementIga.cpp
@@ -17,17 +17,17 @@ BOOST_AUTO_TEST_CASE(ElementCopyMove)
 BOOST_AUTO_TEST_CASE(ExtractNodeValues1D)
 {
     // IGA geometry of a circle (Nurbs curve should exactly fit the circle)
-    std::vector<std::vector<NuTo::NodeSimple*>> controlPoints;
+    std::vector<std::vector<NuTo::DofNode*>> controlPoints;
 
-    NuTo::NodeSimple n1 = NuTo::NodeSimple(Eigen::Vector2d({0, -1}));
-    NuTo::NodeSimple n2 = NuTo::NodeSimple(Eigen::Vector2d({-1, -1}));
-    NuTo::NodeSimple n3 = NuTo::NodeSimple(Eigen::Vector2d({-1, 0}));
-    NuTo::NodeSimple n4 = NuTo::NodeSimple(Eigen::Vector2d({-1, 1}));
-    NuTo::NodeSimple n5 = NuTo::NodeSimple(Eigen::Vector2d({0, 1}));
-    NuTo::NodeSimple n6 = NuTo::NodeSimple(Eigen::Vector2d({1, 1}));
-    NuTo::NodeSimple n7 = NuTo::NodeSimple(Eigen::Vector2d({1, 0}));
-    NuTo::NodeSimple n8 = NuTo::NodeSimple(Eigen::Vector2d({1, -1}));
-    NuTo::NodeSimple n9 = NuTo::NodeSimple(Eigen::Vector2d({0, -1}));
+    NuTo::DofNode n1 = NuTo::DofNode(Eigen::Vector2d({0, -1}));
+    NuTo::DofNode n2 = NuTo::DofNode(Eigen::Vector2d({-1, -1}));
+    NuTo::DofNode n3 = NuTo::DofNode(Eigen::Vector2d({-1, 0}));
+    NuTo::DofNode n4 = NuTo::DofNode(Eigen::Vector2d({-1, 1}));
+    NuTo::DofNode n5 = NuTo::DofNode(Eigen::Vector2d({0, 1}));
+    NuTo::DofNode n6 = NuTo::DofNode(Eigen::Vector2d({1, 1}));
+    NuTo::DofNode n7 = NuTo::DofNode(Eigen::Vector2d({1, 0}));
+    NuTo::DofNode n8 = NuTo::DofNode(Eigen::Vector2d({1, -1}));
+    NuTo::DofNode n9 = NuTo::DofNode(Eigen::Vector2d({0, -1}));
     controlPoints.push_back({&n1, &n2, &n3, &n4, &n5, &n6, &n7, &n8, &n9});
 
     std::vector<double> knots1D = {0, 0, 0, 1 / 4., 1 / 4., 1 / 2., 1 / 2., 3 / 4., 3 / 4., 1, 1, 1};
@@ -61,9 +61,9 @@ BOOST_AUTO_TEST_CASE(ExtractNodeValues1D)
 
 BOOST_AUTO_TEST_CASE(ExtractNodeValuesInstance)
 {
-    std::vector<std::vector<NuTo::NodeSimple*>> controlPoints;
-    NuTo::NodeSimple n1 = NuTo::NodeSimple(2, 2);
-    NuTo::NodeSimple n2 = NuTo::NodeSimple(2, 2);
+    std::vector<std::vector<NuTo::DofNode*>> controlPoints;
+    NuTo::DofNode n1 = NuTo::DofNode(2, 2);
+    NuTo::DofNode n2 = NuTo::DofNode(2, 2);
 
     n1.SetValues(Eigen::Vector2d(11, 12), 1);
     n2.SetValues(Eigen::Vector2d(13, 14), 1);

--- a/test/mechanics/iga/Nurbs.cpp
+++ b/test/mechanics/iga/Nurbs.cpp
@@ -16,34 +16,34 @@ BOOST_AUTO_TEST_CASE(NurbsCopyMove)
 BOOST_AUTO_TEST_CASE(NurbsCurve)
 {
     // IGA geometry of a circle (Nurbs curve should exactly fit the circle)
-    std::vector<std::vector<NuTo::NodeSimple*>> controlPoints;
-    std::vector<NuTo::NodeSimple*> row1;
+    std::vector<std::vector<NuTo::DofNode*>> controlPoints;
+    std::vector<NuTo::DofNode*> row1;
 
-    NuTo::NodeSimple n0 = NuTo::NodeSimple(Eigen::Vector2d({0, -1}));
+    NuTo::DofNode n0 = NuTo::DofNode(Eigen::Vector2d({0, -1}));
     row1.push_back(&n0);
 
-    NuTo::NodeSimple n1 = NuTo::NodeSimple(Eigen::Vector2d({-1, -1}));
+    NuTo::DofNode n1 = NuTo::DofNode(Eigen::Vector2d({-1, -1}));
     row1.push_back(&n1);
 
-    NuTo::NodeSimple n2 = NuTo::NodeSimple(Eigen::Vector2d({-1, 0}));
+    NuTo::DofNode n2 = NuTo::DofNode(Eigen::Vector2d({-1, 0}));
     row1.push_back(&n2);
 
-    NuTo::NodeSimple n3 = NuTo::NodeSimple(Eigen::Vector2d({-1, 1}));
+    NuTo::DofNode n3 = NuTo::DofNode(Eigen::Vector2d({-1, 1}));
     row1.push_back(&n3);
 
-    NuTo::NodeSimple n4 = NuTo::NodeSimple(Eigen::Vector2d({0, 1}));
+    NuTo::DofNode n4 = NuTo::DofNode(Eigen::Vector2d({0, 1}));
     row1.push_back(&n4);
 
-    NuTo::NodeSimple n5 = NuTo::NodeSimple(Eigen::Vector2d({1, 1}));
+    NuTo::DofNode n5 = NuTo::DofNode(Eigen::Vector2d({1, 1}));
     row1.push_back(&n5);
 
-    NuTo::NodeSimple n6 = NuTo::NodeSimple(Eigen::Vector2d({1, 0}));
+    NuTo::DofNode n6 = NuTo::DofNode(Eigen::Vector2d({1, 0}));
     row1.push_back(&n6);
 
-    NuTo::NodeSimple n7 = NuTo::NodeSimple(Eigen::Vector2d({1, -1}));
+    NuTo::DofNode n7 = NuTo::DofNode(Eigen::Vector2d({1, -1}));
     row1.push_back(&n7);
 
-    NuTo::NodeSimple n8 = NuTo::NodeSimple(Eigen::Vector2d({0, -1}));
+    NuTo::DofNode n8 = NuTo::DofNode(Eigen::Vector2d({0, -1}));
     row1.push_back(&n8);
 
     controlPoints.push_back(row1);
@@ -103,68 +103,68 @@ BOOST_AUTO_TEST_CASE(NurbsSurface)
 {
 
     // IGA geometry of a circle (Nurbs curve should exactly fit the circle)
-    std::vector<std::vector<NuTo::NodeSimple*>> controlPoints;
+    std::vector<std::vector<NuTo::DofNode*>> controlPoints;
 
-    std::vector<NuTo::NodeSimple*> row1;
-    NuTo::NodeSimple n0 = NuTo::NodeSimple(Eigen::Vector3d({0, -1, 0}));
+    std::vector<NuTo::DofNode*> row1;
+    NuTo::DofNode n0 = NuTo::DofNode(Eigen::Vector3d({0, -1, 0}));
     row1.push_back(&n0);
-    NuTo::NodeSimple n1 = NuTo::NodeSimple(Eigen::Vector3d({-1, -1, 0}));
+    NuTo::DofNode n1 = NuTo::DofNode(Eigen::Vector3d({-1, -1, 0}));
     row1.push_back(&n1);
-    NuTo::NodeSimple n2 = NuTo::NodeSimple(Eigen::Vector3d({-1, 0, 0}));
+    NuTo::DofNode n2 = NuTo::DofNode(Eigen::Vector3d({-1, 0, 0}));
     row1.push_back(&n2);
-    NuTo::NodeSimple n3 = NuTo::NodeSimple(Eigen::Vector3d({-1, 1, 0}));
+    NuTo::DofNode n3 = NuTo::DofNode(Eigen::Vector3d({-1, 1, 0}));
     row1.push_back(&n3);
-    NuTo::NodeSimple n4 = NuTo::NodeSimple(Eigen::Vector3d({0, 1, 0}));
+    NuTo::DofNode n4 = NuTo::DofNode(Eigen::Vector3d({0, 1, 0}));
     row1.push_back(&n4);
-    NuTo::NodeSimple n5 = NuTo::NodeSimple(Eigen::Vector3d({1, 1, 0}));
+    NuTo::DofNode n5 = NuTo::DofNode(Eigen::Vector3d({1, 1, 0}));
     row1.push_back(&n5);
-    NuTo::NodeSimple n6 = NuTo::NodeSimple(Eigen::Vector3d({1, 0, 0}));
+    NuTo::DofNode n6 = NuTo::DofNode(Eigen::Vector3d({1, 0, 0}));
     row1.push_back(&n6);
-    NuTo::NodeSimple n7 = NuTo::NodeSimple(Eigen::Vector3d({1, -1, 0}));
+    NuTo::DofNode n7 = NuTo::DofNode(Eigen::Vector3d({1, -1, 0}));
     row1.push_back(&n7);
-    NuTo::NodeSimple n8 = NuTo::NodeSimple(Eigen::Vector3d({0, -1, 0}));
+    NuTo::DofNode n8 = NuTo::DofNode(Eigen::Vector3d({0, -1, 0}));
     row1.push_back(&n8);
     controlPoints.push_back(row1);
 
-    std::vector<NuTo::NodeSimple*> row2;
-    NuTo::NodeSimple n9 = NuTo::NodeSimple(Eigen::Vector3d({0, -1, 1}));
+    std::vector<NuTo::DofNode*> row2;
+    NuTo::DofNode n9 = NuTo::DofNode(Eigen::Vector3d({0, -1, 1}));
     row2.push_back(&n9);
-    NuTo::NodeSimple n10 = NuTo::NodeSimple(Eigen::Vector3d({-1, -1, 1}));
+    NuTo::DofNode n10 = NuTo::DofNode(Eigen::Vector3d({-1, -1, 1}));
     row2.push_back(&n10);
-    NuTo::NodeSimple n11 = NuTo::NodeSimple(Eigen::Vector3d({-1, 0, 1}));
+    NuTo::DofNode n11 = NuTo::DofNode(Eigen::Vector3d({-1, 0, 1}));
     row2.push_back(&n11);
-    NuTo::NodeSimple n12 = NuTo::NodeSimple(Eigen::Vector3d({-1, 1, 1}));
+    NuTo::DofNode n12 = NuTo::DofNode(Eigen::Vector3d({-1, 1, 1}));
     row2.push_back(&n12);
-    NuTo::NodeSimple n13 = NuTo::NodeSimple(Eigen::Vector3d({0, 1, 1}));
+    NuTo::DofNode n13 = NuTo::DofNode(Eigen::Vector3d({0, 1, 1}));
     row2.push_back(&n13);
-    NuTo::NodeSimple n14 = NuTo::NodeSimple(Eigen::Vector3d({1, 1, 1}));
+    NuTo::DofNode n14 = NuTo::DofNode(Eigen::Vector3d({1, 1, 1}));
     row2.push_back(&n14);
-    NuTo::NodeSimple n15 = NuTo::NodeSimple(Eigen::Vector3d({1, 0, 1}));
+    NuTo::DofNode n15 = NuTo::DofNode(Eigen::Vector3d({1, 0, 1}));
     row2.push_back(&n15);
-    NuTo::NodeSimple n16 = NuTo::NodeSimple(Eigen::Vector3d({1, -1, 1}));
+    NuTo::DofNode n16 = NuTo::DofNode(Eigen::Vector3d({1, -1, 1}));
     row2.push_back(&n16);
-    NuTo::NodeSimple n17 = NuTo::NodeSimple(Eigen::Vector3d({0, -1, 1}));
+    NuTo::DofNode n17 = NuTo::DofNode(Eigen::Vector3d({0, -1, 1}));
     row2.push_back(&n17);
     controlPoints.push_back(row2);
 
-    std::vector<NuTo::NodeSimple*> row3;
-    NuTo::NodeSimple n18 = NuTo::NodeSimple(Eigen::Vector3d({0, -1, 2}));
+    std::vector<NuTo::DofNode*> row3;
+    NuTo::DofNode n18 = NuTo::DofNode(Eigen::Vector3d({0, -1, 2}));
     row3.push_back(&n18);
-    NuTo::NodeSimple n19 = NuTo::NodeSimple(Eigen::Vector3d({-1, -1, 2}));
+    NuTo::DofNode n19 = NuTo::DofNode(Eigen::Vector3d({-1, -1, 2}));
     row3.push_back(&n19);
-    NuTo::NodeSimple n20 = NuTo::NodeSimple(Eigen::Vector3d({-1, 0, 2}));
+    NuTo::DofNode n20 = NuTo::DofNode(Eigen::Vector3d({-1, 0, 2}));
     row3.push_back(&n20);
-    NuTo::NodeSimple n21 = NuTo::NodeSimple(Eigen::Vector3d({-1, 1, 2}));
+    NuTo::DofNode n21 = NuTo::DofNode(Eigen::Vector3d({-1, 1, 2}));
     row3.push_back(&n21);
-    NuTo::NodeSimple n22 = NuTo::NodeSimple(Eigen::Vector3d({0, 1, 2}));
+    NuTo::DofNode n22 = NuTo::DofNode(Eigen::Vector3d({0, 1, 2}));
     row3.push_back(&n22);
-    NuTo::NodeSimple n23 = NuTo::NodeSimple(Eigen::Vector3d({1, 1, 2}));
+    NuTo::DofNode n23 = NuTo::DofNode(Eigen::Vector3d({1, 1, 2}));
     row3.push_back(&n23);
-    NuTo::NodeSimple n24 = NuTo::NodeSimple(Eigen::Vector3d({1, 0, 2}));
+    NuTo::DofNode n24 = NuTo::DofNode(Eigen::Vector3d({1, 0, 2}));
     row3.push_back(&n24);
-    NuTo::NodeSimple n25 = NuTo::NodeSimple(Eigen::Vector3d({1, -1, 2}));
+    NuTo::DofNode n25 = NuTo::DofNode(Eigen::Vector3d({1, -1, 2}));
     row3.push_back(&n25);
-    NuTo::NodeSimple n26 = NuTo::NodeSimple(Eigen::Vector3d({0, -1, 2}));
+    NuTo::DofNode n26 = NuTo::DofNode(Eigen::Vector3d({0, -1, 2}));
     row3.push_back(&n26);
     controlPoints.push_back(row3);
 

--- a/test/mechanics/integrands/GradientDamage.cpp
+++ b/test/mechanics/integrands/GradientDamage.cpp
@@ -2,7 +2,7 @@
 
 #include "nuto/mechanics/integrands/GradientDamage.h"
 
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 #include "nuto/mechanics/elements/ElementCollection.h"
 #include "nuto/mechanics/interpolation/InterpolationTrussLobatto.h"
 
@@ -79,23 +79,23 @@ void CheckHessian0(ElementCollectionFem& element, Integrands::GradientDamage<1>&
 BOOST_AUTO_TEST_CASE(GradientDamage1D)
 {
     // coordinate element
-    NodeCoordinates n0(0);
-    NodeCoordinates n1(1);
-    NodeCoordinates n2(2);
+    CoordinateNode n0(0);
+    CoordinateNode n1(1);
+    CoordinateNode n2(2);
 
     InterpolationTrussLobatto interpolation(2);
     ElementCollectionFem element({{n0, n1, n2}, interpolation});
 
     // displacement element nodes
-    NodeSimple nd0(0);
-    NodeSimple nd1(0);
-    NodeSimple nd2(0);
+    DofNode nd0(0);
+    DofNode nd1(0);
+    DofNode nd2(0);
     DofType disp("displacements", 1);
     element.AddDofElement(disp, {{nd0, nd1, nd2}, interpolation});
 
-    NodeSimple ne0(0);
-    NodeSimple ne1(0);
-    NodeSimple ne2(0);
+    DofNode ne0(0);
+    DofNode ne1(0);
+    DofNode ne2(0);
     ScalarDofType eeq("eeq");
     element.AddDofElement(eeq, {{ne0, ne1, ne2}, interpolation});
 

--- a/test/mechanics/integrands/GradientDamage.cpp
+++ b/test/mechanics/integrands/GradientDamage.cpp
@@ -84,7 +84,8 @@ BOOST_AUTO_TEST_CASE(GradientDamage1D)
     CoordinateNode n2(2);
 
     InterpolationTrussLobatto interpolation(2);
-    ElementCollectionFem element({{n0, n1, n2}, interpolation});
+    CoordinateElementFem cElm{{n0, n1, n2}, interpolation};
+    ElementCollectionFem element(cElm);
 
     // displacement element nodes
     DofNode nd0(0);

--- a/test/mechanics/integrands/GradientDamage.cpp
+++ b/test/mechanics/integrands/GradientDamage.cpp
@@ -20,7 +20,7 @@ void CheckHessian0(ElementCollectionFem& element, Integrands::GradientDamage<1>&
 
     CellData cellData(element, 0);
     Eigen::VectorXd ip = Eigen::Vector2d::Ones() * 0.67124;
-    Jacobian jac(element.CoordinateElement().ExtractNodeValues(),
+    Jacobian jac(element.CoordinateElement().ExtractCoordinates(),
                  element.CoordinateElement().GetDerivativeShapeFunctions(ip));
 
     CellIpData cipd(cellData, jac, ip, 0);

--- a/test/mechanics/integrands/GradientDamage.cpp
+++ b/test/mechanics/integrands/GradientDamage.cpp
@@ -79,9 +79,9 @@ void CheckHessian0(ElementCollectionFem& element, Integrands::GradientDamage<1>&
 BOOST_AUTO_TEST_CASE(GradientDamage1D)
 {
     // coordinate element
-    NodeSimple n0(0);
-    NodeSimple n1(1);
-    NodeSimple n2(2);
+    NodeCoordinates n0(0);
+    NodeCoordinates n1(1);
+    NodeCoordinates n2(2);
 
     InterpolationTrussLobatto interpolation(2);
     ElementCollectionFem element({{n0, n1, n2}, interpolation});

--- a/test/mechanics/integrands/HistoryData.cpp
+++ b/test/mechanics/integrands/HistoryData.cpp
@@ -50,9 +50,9 @@ public:
 BOOST_AUTO_TEST_CASE(Pass_Data_To_Integrand)
 {
     InterpolationTrussLinear interpolation;
-    NodeSimple n0(0);
-    NodeSimple n1(42);
-    DofElementFem coordinateElement({n0, n1}, interpolation);
+    NodeCoordinates n0(0);
+    NodeCoordinates n1(42);
+    CoordinateElementFem coordinateElement({n0, n1}, interpolation);
     ElementCollectionFem element(coordinateElement);
 
     CustomIntegrand integrand;

--- a/test/mechanics/integrands/HistoryData.cpp
+++ b/test/mechanics/integrands/HistoryData.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(Pass_Data_To_Integrand)
     InterpolationTrussLinear interpolation;
     NodeSimple n0(0);
     NodeSimple n1(42);
-    ElementFem coordinateElement({n0, n1}, interpolation);
+    DofElementFem coordinateElement({n0, n1}, interpolation);
     ElementCollectionFem element(coordinateElement);
 
     CustomIntegrand integrand;

--- a/test/mechanics/integrands/HistoryData.cpp
+++ b/test/mechanics/integrands/HistoryData.cpp
@@ -3,7 +3,7 @@
 #include "nuto/mechanics/cell/Cell.h"
 #include "nuto/mechanics/integrationtypes/IntegrationTypeTensorProduct.h"
 #include "nuto/mechanics/interpolation/InterpolationTrussLinear.h"
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 #include "nuto/mechanics/elements/ElementCollection.h"
 
 #include <set>
@@ -50,8 +50,8 @@ public:
 BOOST_AUTO_TEST_CASE(Pass_Data_To_Integrand)
 {
     InterpolationTrussLinear interpolation;
-    NodeCoordinates n0(0);
-    NodeCoordinates n1(42);
+    CoordinateNode n0(0);
+    CoordinateNode n1(42);
     CoordinateElementFem coordinateElement({n0, n1}, interpolation);
     ElementCollectionFem element(coordinateElement);
 

--- a/test/mechanics/integrands/NeumannBc.cpp
+++ b/test/mechanics/integrands/NeumannBc.cpp
@@ -2,7 +2,7 @@
 
 #include "nuto/mechanics/integrands/NeumannBc.h"
 
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 #include "nuto/mechanics/elements/ElementCollection.h"
 #include "nuto/mechanics/interpolation/InterpolationTrussLinear.h"
 #include "nuto/mechanics/interpolation/InterpolationTriangleLinear.h"
@@ -17,15 +17,15 @@ constexpr int ipNum = 0;
 BOOST_AUTO_TEST_CASE(NeumannBc1Din2D)
 {
     // coordinate element
-    NodeCoordinates nc0(Eigen::Vector2d(0, 0));
-    NodeCoordinates nc1(Eigen::Vector2d(2, 2));
+    CoordinateNode nc0(Eigen::Vector2d(0, 0));
+    CoordinateNode nc1(Eigen::Vector2d(2, 2));
     InterpolationTrussLinear coordinateInterpolation;
     ElementCollectionFem element({{nc0, nc1}, coordinateInterpolation});
 
     // displacement nodes
     DofType dof("displacements", 2);
-    NodeSimple nd0(Eigen::Vector2d(0, 0));
-    NodeSimple nd1(Eigen::Vector2d(0, 0));
+    DofNode nd0(Eigen::Vector2d(0, 0));
+    DofNode nd1(Eigen::Vector2d(0, 0));
     InterpolationTrussLinear displacementInterpolation;
     element.AddDofElement(dof, {{nd0, nd1}, displacementInterpolation});
 
@@ -78,17 +78,17 @@ BOOST_AUTO_TEST_CASE(NeumannBc1Din2D)
 
 BOOST_AUTO_TEST_CASE(NeumannBc2Din3D)
 {
-    std::vector<NodeSimple> nodesDisp;
+    std::vector<DofNode> nodesDisp;
     for (int i = 0; i < 3; i++)
-        nodesDisp.push_back(NodeSimple(Eigen::Vector3d(0, 0, 0)));
+        nodesDisp.push_back(DofNode(Eigen::Vector3d(0, 0, 0)));
 
-    std::vector<NodeCoordinates> nodes;
-    nodes.push_back(NodeCoordinates(Eigen::Vector3d(1, 0, 0)));
-    nodes.push_back(NodeCoordinates(Eigen::Vector3d(0, 1, 0)));
-    nodes.push_back(NodeCoordinates(Eigen::Vector3d(0, 0, 1)));
+    std::vector<CoordinateNode> nodes;
+    nodes.push_back(CoordinateNode(Eigen::Vector3d(1, 0, 0)));
+    nodes.push_back(CoordinateNode(Eigen::Vector3d(0, 1, 0)));
+    nodes.push_back(CoordinateNode(Eigen::Vector3d(0, 0, 1)));
 
-    std::vector<NodeCoordinates*> nodePtrs;
-    std::vector<NodeSimple*> nodesDispPtrs;
+    std::vector<CoordinateNode*> nodePtrs;
+    std::vector<DofNode*> nodesDispPtrs;
 
     nodePtrs.push_back(&nodes[0]);
     nodePtrs.push_back(&nodes[1]);

--- a/test/mechanics/integrands/NeumannBc.cpp
+++ b/test/mechanics/integrands/NeumannBc.cpp
@@ -17,8 +17,8 @@ constexpr int ipNum = 0;
 BOOST_AUTO_TEST_CASE(NeumannBc1Din2D)
 {
     // coordinate element
-    NodeSimple nc0(Eigen::Vector2d(0, 0));
-    NodeSimple nc1(Eigen::Vector2d(2, 2));
+    NodeCoordinates nc0(Eigen::Vector2d(0, 0));
+    NodeCoordinates nc1(Eigen::Vector2d(2, 2));
     InterpolationTrussLinear coordinateInterpolation;
     ElementCollectionFem element({{nc0, nc1}, coordinateInterpolation});
 
@@ -82,12 +82,12 @@ BOOST_AUTO_TEST_CASE(NeumannBc2Din3D)
     for (int i = 0; i < 3; i++)
         nodesDisp.push_back(NodeSimple(Eigen::Vector3d(0, 0, 0)));
 
-    std::vector<NodeSimple> nodes;
-    nodes.push_back(NodeSimple(Eigen::Vector3d(1, 0, 0)));
-    nodes.push_back(NodeSimple(Eigen::Vector3d(0, 1, 0)));
-    nodes.push_back(NodeSimple(Eigen::Vector3d(0, 0, 1)));
+    std::vector<NodeCoordinates> nodes;
+    nodes.push_back(NodeCoordinates(Eigen::Vector3d(1, 0, 0)));
+    nodes.push_back(NodeCoordinates(Eigen::Vector3d(0, 1, 0)));
+    nodes.push_back(NodeCoordinates(Eigen::Vector3d(0, 0, 1)));
 
-    std::vector<NodeSimple*> nodePtrs;
+    std::vector<NodeCoordinates*> nodePtrs;
     std::vector<NodeSimple*> nodesDispPtrs;
 
     nodePtrs.push_back(&nodes[0]);

--- a/test/mechanics/integrands/NeumannBc.cpp
+++ b/test/mechanics/integrands/NeumannBc.cpp
@@ -20,7 +20,8 @@ BOOST_AUTO_TEST_CASE(NeumannBc1Din2D)
     CoordinateNode nc0(Eigen::Vector2d(0, 0));
     CoordinateNode nc1(Eigen::Vector2d(2, 2));
     InterpolationTrussLinear coordinateInterpolation;
-    ElementCollectionFem element({{nc0, nc1}, coordinateInterpolation});
+    CoordinateElementFem cElm{{nc0, nc1}, coordinateInterpolation};
+    ElementCollectionFem element(cElm);
 
     // displacement nodes
     DofType dof("displacements", 2);
@@ -100,7 +101,8 @@ BOOST_AUTO_TEST_CASE(NeumannBc2Din3D)
 
     // coordinate element
     InterpolationTriangleLinear coordinateInterpolation;
-    ElementCollectionFem element({nodePtrs, coordinateInterpolation});
+    CoordinateElementFem cElm{nodePtrs, coordinateInterpolation};
+    ElementCollectionFem element(cElm);
 
     // displacement nodes
     DofType dof("displacements", 3);

--- a/test/mechanics/integrands/NeumannBc.cpp
+++ b/test/mechanics/integrands/NeumannBc.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(NeumannBc1Din2D)
     Integrands::NeumannBc<2> neumannIntegrand(dof, p);
 
     CellData cellData(element, cellID);
-    Jacobian dummyJac(element.CoordinateElement().ExtractNodeValues(), // jacobian not needed for N.
+    Jacobian dummyJac(element.CoordinateElement().ExtractCoordinates(), // jacobian not needed for N.
                       element.CoordinateElement().GetDerivativeShapeFunctions(Eigen::VectorXd::Constant(1, 0.)));
 
 
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(NeumannBc2Din3D)
     Integrands::NeumannBc<3> neumannIntegrand(dof, p);
 
     CellData cellData(element, cellID);
-    Jacobian dummyJac(element.CoordinateElement().ExtractNodeValues(), // jacobian not needed for N.
+    Jacobian dummyJac(element.CoordinateElement().ExtractCoordinates(), // jacobian not needed for N.
                       element.CoordinateElement().GetDerivativeShapeFunctions(Eigen::VectorXd::Constant(2, 1, 0.)));
 
     std::vector<Eigen::Vector2d> points;

--- a/test/mechanics/mesh/CMakeLists.txt
+++ b/test/mechanics/mesh/CMakeLists.txt
@@ -5,6 +5,9 @@ add_unit_test(MeshFem
     mechanics/interpolation/InterpolationTriangleQuadratic.cpp
     mechanics/mesh/MeshFemDofConvert)
 
+add_unit_test(GeometryMeshFem
+    mechanics/elements/ElementShapeFunctions)
+
 add_unit_test(UnitMeshFem
     mechanics/mesh/MeshFem
     mechanics/interpolation/InterpolationTriangleLinear.cpp

--- a/test/mechanics/mesh/CMakeLists.txt
+++ b/test/mechanics/mesh/CMakeLists.txt
@@ -6,7 +6,11 @@ add_unit_test(MeshFem
     mechanics/mesh/MeshFemDofConvert)
 
 add_unit_test(GeometryMeshFem
-    mechanics/elements/ElementShapeFunctions)
+    mechanics/interpolation/InterpolationTriangleLinear.cpp
+    mechanics/interpolation/InterpolationTrussLinear.cpp
+    mechanics/interpolation/InterpolationQuadLinear.cpp
+    mechanics/interpolation/InterpolationBrickLinear.cpp
+    )
 
 add_unit_test(UnitMeshFem
     mechanics/mesh/GeometryMeshFem

--- a/test/mechanics/mesh/CMakeLists.txt
+++ b/test/mechanics/mesh/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_unit_test(MeshFem
+    mechanics/mesh/GeometryMeshFem
     mechanics/interpolation/InterpolationTrussLinear.cpp
     mechanics/interpolation/InterpolationTriangleLinear.cpp
     mechanics/interpolation/InterpolationQuadLinear.cpp

--- a/test/mechanics/mesh/CMakeLists.txt
+++ b/test/mechanics/mesh/CMakeLists.txt
@@ -9,7 +9,7 @@ add_unit_test(GeometryMeshFem
     mechanics/elements/ElementShapeFunctions)
 
 add_unit_test(UnitMeshFem
-    mechanics/mesh/MeshFem
+    mechanics/mesh/GeometryMeshFem
     mechanics/interpolation/InterpolationTriangleLinear.cpp
     mechanics/interpolation/InterpolationTrussLinear.cpp
     mechanics/interpolation/InterpolationQuadLinear.cpp
@@ -19,7 +19,7 @@ add_unit_test(UnitMeshFem
 create_symlink("meshes")
 
 add_unit_test(MeshGmsh
-    mechanics/mesh/MeshFem
+    mechanics/mesh/GeometryMeshFem
     math/Legendre
     mechanics/interpolation/InterpolationTrussLinear.cpp
     mechanics/interpolation/InterpolationTrussLobatto.cpp

--- a/test/mechanics/mesh/GeometryMeshFem.cpp
+++ b/test/mechanics/mesh/GeometryMeshFem.cpp
@@ -5,11 +5,6 @@
 #include "nuto/mechanics/interpolation/InterpolationQuadLinear.h"
 #include "nuto/mechanics/interpolation/InterpolationTriangleQuadratic.h"
 
-void SetStuff(NuTo::GeometryMeshFem& m)
-{
-    m.Nodes[0].SetValue(0, 0);
-}
-
 NuTo::GeometryMeshFem DummyMesh()
 {
     NuTo::GeometryMeshFem mesh;
@@ -19,7 +14,7 @@ NuTo::GeometryMeshFem DummyMesh()
     auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d({2, 0}));
     auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d({0, 3}));
 
-    auto& e0 = mesh.Elements.Add({{{n0, n1, n2}, interpolation}});
+    mesh.Elements.Add({{n0, n1, n2}, interpolation});
 
     return mesh;
 }
@@ -29,16 +24,15 @@ BOOST_AUTO_TEST_CASE(MeshAddStuff)
     NuTo::GeometryMeshFem mesh = DummyMesh();
 
     auto& e0 = mesh.Elements[0];
-    BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({1, 0, 2, 0, 0, 3}), 6);
+    BoostUnitTest::CheckVector(e0.ExtractNodeValues(), std::vector<double>({1, 0, 2, 0, 0, 3}), 6);
 
     mesh.CoordinateNodes[0].SetCoordinate(0, 4);
-    BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({4, 0, 2, 0, 0, 3}), 6);
+    BoostUnitTest::CheckVector(e0.ExtractNodeValues(), std::vector<double>({4, 0, 2, 0, 0, 3}), 6);
 
     NuTo::GeometryMeshFem meshMoved = std::move(mesh);
     meshMoved.CoordinateNodes[0].SetCoordinate(0, 42);
     auto& e0FromMove = meshMoved.Elements[0];
-    BoostUnitTest::CheckVector(e0FromMove.CoordinateElement().ExtractNodeValues(),
-                               std::vector<double>({42, 0, 2, 0, 0, 3}), 6);
+    BoostUnitTest::CheckVector(e0FromMove.ExtractNodeValues(), std::vector<double>({42, 0, 2, 0, 0, 3}), 6);
 }
 
 BOOST_AUTO_TEST_CASE(MeshNodeSelectionCoords)

--- a/test/mechanics/mesh/GeometryMeshFem.cpp
+++ b/test/mechanics/mesh/GeometryMeshFem.cpp
@@ -24,15 +24,15 @@ BOOST_AUTO_TEST_CASE(MeshAddStuff)
     NuTo::GeometryMeshFem mesh = DummyMesh();
 
     auto& e0 = mesh.Elements[0];
-    BoostUnitTest::CheckVector(e0.ExtractNodeValues(), std::vector<double>({1, 0, 2, 0, 0, 3}), 6);
+    BoostUnitTest::CheckVector(e0.ExtractCoordinates(), std::vector<double>({1, 0, 2, 0, 0, 3}), 6);
 
     mesh.CoordinateNodes[0].SetCoordinate(0, 4);
-    BoostUnitTest::CheckVector(e0.ExtractNodeValues(), std::vector<double>({4, 0, 2, 0, 0, 3}), 6);
+    BoostUnitTest::CheckVector(e0.ExtractCoordinates(), std::vector<double>({4, 0, 2, 0, 0, 3}), 6);
 
     NuTo::GeometryMeshFem meshMoved = std::move(mesh);
     meshMoved.CoordinateNodes[0].SetCoordinate(0, 42);
     auto& e0FromMove = meshMoved.Elements[0];
-    BoostUnitTest::CheckVector(e0FromMove.ExtractNodeValues(), std::vector<double>({42, 0, 2, 0, 0, 3}), 6);
+    BoostUnitTest::CheckVector(e0FromMove.ExtractCoordinates(), std::vector<double>({42, 0, 2, 0, 0, 3}), 6);
 }
 
 BOOST_AUTO_TEST_CASE(MeshNodeSelectionCoords)

--- a/test/mechanics/mesh/GeometryMeshFem.cpp
+++ b/test/mechanics/mesh/GeometryMeshFem.cpp
@@ -65,3 +65,12 @@ BOOST_AUTO_TEST_CASE(MeshNodeSelectionAxis)
         BOOST_CHECK(group1.Empty());
     }
 }
+
+BOOST_AUTO_TEST_CASE(MeshSelectTotal)
+{
+    NuTo::GeometryMeshFem mesh = DummyMesh();
+    auto nodes = mesh.NodesTotal();
+    BOOST_CHECK_EQUAL(nodes.Size(), 3);
+    auto elements = mesh.ElementsTotal();
+    BOOST_CHECK_EQUAL(elements.Size(), 1);
+}

--- a/test/mechanics/mesh/GeometryMeshFem.cpp
+++ b/test/mechanics/mesh/GeometryMeshFem.cpp
@@ -1,0 +1,73 @@
+#include "BoostUnitTest.h"
+#include "nuto/mechanics/mesh/GeometryMeshFem.h"
+#include "nuto/mechanics/interpolation/InterpolationTrussLinear.h"
+#include "nuto/mechanics/interpolation/InterpolationTriangleLinear.h"
+#include "nuto/mechanics/interpolation/InterpolationQuadLinear.h"
+#include "nuto/mechanics/interpolation/InterpolationTriangleQuadratic.h"
+
+void SetStuff(NuTo::GeometryMeshFem& m)
+{
+    m.Nodes[0].SetValue(0, 0);
+}
+
+NuTo::GeometryMeshFem DummyMesh()
+{
+    NuTo::GeometryMeshFem mesh;
+    auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
+
+    auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d({1, 0}));
+    auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d({2, 0}));
+    auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d({0, 3}));
+
+    auto& e0 = mesh.Elements.Add({{{n0, n1, n2}, interpolation}});
+
+    return mesh;
+}
+
+BOOST_AUTO_TEST_CASE(MeshAddStuff)
+{
+    NuTo::GeometryMeshFem mesh = DummyMesh();
+
+    auto& e0 = mesh.Elements[0];
+    BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({1, 0, 2, 0, 0, 3}), 6);
+
+    mesh.CoordinateNodes[0].SetCoordinate(0, 4);
+    BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({4, 0, 2, 0, 0, 3}), 6);
+
+    NuTo::GeometryMeshFem meshMoved = std::move(mesh);
+    meshMoved.CoordinateNodes[0].SetCoordinate(0, 42);
+    auto& e0FromMove = meshMoved.Elements[0];
+    BoostUnitTest::CheckVector(e0FromMove.CoordinateElement().ExtractNodeValues(),
+                               std::vector<double>({42, 0, 2, 0, 0, 3}), 6);
+}
+
+BOOST_AUTO_TEST_CASE(MeshNodeSelectionCoords)
+{
+    NuTo::GeometryMeshFem mesh = DummyMesh();
+
+    // selection of coordinate nodes
+    {
+        const auto& n = mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3));
+        BoostUnitTest::CheckEigenMatrix(n.GetCoordinates(), Eigen::Vector2d(0, 3));
+        BOOST_CHECK_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3.00001)), NuTo::Exception);
+        BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3.00001), 1e-4));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(MeshNodeSelectionAxis)
+{
+    NuTo::GeometryMeshFem mesh = DummyMesh();
+
+    {
+        auto& nd0 = mesh.NodeAtCoordinate(Eigen::Vector2d(1, 0));
+        auto& nd1 = mesh.NodeAtCoordinate(Eigen::Vector2d(2, 0));
+
+        auto group0 = mesh.NodesAtAxis(NuTo::eDirection::Y);
+        BOOST_CHECK_EQUAL(group0.Size(), 2);
+        BOOST_CHECK(group0.Contains(nd0));
+        BOOST_CHECK(group0.Contains(nd1));
+
+        auto group1 = mesh.NodesAtAxis(NuTo::eDirection::Y, 2.);
+        BOOST_CHECK(group1.Empty());
+    }
+}

--- a/test/mechanics/mesh/MeshFem.cpp
+++ b/test/mechanics/mesh/MeshFem.cpp
@@ -17,9 +17,9 @@ NuTo::MeshFem DummyMesh(NuTo::GeometryMeshFem& geoMesh, NuTo::DofType dofType)
     NuTo::MeshFem mesh(geoMesh);
     auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
 
-    auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d({1, 0}));
-    auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d({2, 0}));
-    auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d({0, 3}));
+    auto& n0 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d({1, 0}));
+    auto& n1 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d({2, 0}));
+    auto& n2 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d({0, 3}));
 
     auto& nd0 = mesh.Nodes.Add(42);
     auto& nd1 = mesh.Nodes.Add(4);
@@ -50,25 +50,6 @@ BOOST_AUTO_TEST_CASE(AllocateInstances)
     {
         BOOST_CHECK_EQUAL(node.GetNumInstances(), 10);
     }
-}
-
-BOOST_AUTO_TEST_CASE(MeshAddStuff)
-{
-    NuTo::DofType d("Dof", 1);
-    NuTo::GeometryMeshFem geoMesh;
-    NuTo::MeshFem mesh = DummyMesh(geoMesh, d);
-
-    auto& e0 = mesh.Elements[0];
-    BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({1, 0, 2, 0, 0, 3}), 6);
-
-    mesh.CoordinateNodes[0].SetCoordinate(0, 4);
-    BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({4, 0, 2, 0, 0, 3}), 6);
-
-    NuTo::MeshFem meshMoved = std::move(mesh);
-    meshMoved.CoordinateNodes[0].SetCoordinate(0, 42);
-    auto& e0FromMove = meshMoved.Elements[0];
-    BoostUnitTest::CheckVector(e0FromMove.CoordinateElement().ExtractNodeValues(),
-                               std::vector<double>({42, 0, 2, 0, 0, 3}), 6);
 }
 
 BOOST_AUTO_TEST_CASE(MeshNodeSelectionCoords)
@@ -142,10 +123,10 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
      */
     NuTo::GeometryMeshFem geoMesh;
     NuTo::MeshFem mesh(geoMesh);
-    auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
-    auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
-    auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
-    auto& n3 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 1));
+    auto& n0 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
+    auto& n1 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
+    auto& n2 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
+    auto& n3 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(1, 1));
 
     auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
     auto& cElm0 = geoMesh.Elements.Add({{n0, n1, n2}, interpolation});
@@ -155,7 +136,7 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
     mesh.Elements.Add(cElm1);
 
     int expectedNumCoordinateNodes = 4;
-    BOOST_CHECK_EQUAL(mesh.CoordinateNodes.Size(), expectedNumCoordinateNodes);
+    BOOST_CHECK_EQUAL(geoMesh.CoordinateNodes.Size(), expectedNumCoordinateNodes);
 
 
     // add linear dof type
@@ -166,7 +147,7 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
     int expectedNumDof0Nodes = expectedNumCoordinateNodes; // same interpolation
 
     BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumDof0Nodes);
-    BOOST_CHECK_EQUAL(mesh.CoordinateNodes.Size(), expectedNumCoordinateNodes);
+    BOOST_CHECK_EQUAL(geoMesh.CoordinateNodes.Size(), expectedNumCoordinateNodes);
     BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 0), dof0));
 
 
@@ -205,12 +186,12 @@ BOOST_AUTO_TEST_CASE(MeshConvertFromCoordinates)
      */
     NuTo::GeometryMeshFem geoMesh;
     NuTo::MeshFem mesh(geoMesh);
-    auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
-    auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
-    auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
-    auto& n3 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 1));
-    auto& n4 = mesh.CoordinateNodes.Add(Eigen::Vector2d(2, 0));
-    auto& n5 = mesh.CoordinateNodes.Add(Eigen::Vector2d(2, 1));
+    auto& n0 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
+    auto& n1 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
+    auto& n2 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
+    auto& n3 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(1, 1));
+    auto& n4 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(2, 0));
+    auto& n5 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(2, 1));
 
     auto& interpolationTriangle = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
     auto& interpolationQuad = mesh.CreateInterpolation(NuTo::InterpolationQuadLinear());
@@ -220,7 +201,7 @@ BOOST_AUTO_TEST_CASE(MeshConvertFromCoordinates)
     mesh.Elements.Add(cElm1);
 
     int expectedNumCoordinateNodes = 6;
-    BOOST_CHECK_EQUAL(mesh.CoordinateNodes.Size(), expectedNumCoordinateNodes);
+    BOOST_CHECK_EQUAL(geoMesh.CoordinateNodes.Size(), expectedNumCoordinateNodes);
 
 
     // add linear dof type
@@ -238,9 +219,9 @@ BOOST_AUTO_TEST_CASE(MeshNodesTotalDof)
 {
     NuTo::GeometryMeshFem geoMesh;
     NuTo::MeshFem mesh(geoMesh);
-    auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
-    auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
-    auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
+    auto& n0 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
+    auto& n1 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
+    auto& n2 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
 
     auto& interpolationTriangle = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
     auto& interpolationTruss = mesh.CreateInterpolation(NuTo::InterpolationTrussLinear());
@@ -272,9 +253,9 @@ BOOST_AUTO_TEST_CASE(PartialAddDofConvert)
 {
     NuTo::GeometryMeshFem geoMesh;
     NuTo::MeshFem mesh(geoMesh);
-    auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
-    auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
-    auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
+    auto& n0 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
+    auto& n1 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
+    auto& n2 = geoMesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
 
     auto& interpolationTriangle = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
     auto& interpolationTruss = mesh.CreateInterpolation(NuTo::InterpolationTrussLinear());

--- a/test/mechanics/mesh/MeshFem.cpp
+++ b/test/mechanics/mesh/MeshFem.cpp
@@ -54,11 +54,11 @@ BOOST_AUTO_TEST_CASE(MeshAddStuff)
     auto& e0 = mesh.Elements[0];
     BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({1, 0, 2, 0, 0, 3}), 6);
 
-    mesh.CoordinateNodes[0].SetValue(0, 4);
+    mesh.CoordinateNodes[0].SetCoordinate(0, 4);
     BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({4, 0, 2, 0, 0, 3}), 6);
 
     NuTo::MeshFem meshMoved = std::move(mesh);
-    meshMoved.CoordinateNodes[0].SetValue(0, 42);
+    meshMoved.CoordinateNodes[0].SetCoordinate(0, 42);
     auto& e0FromMove = meshMoved.Elements[0];
     BoostUnitTest::CheckVector(e0FromMove.CoordinateElement().ExtractNodeValues(),
                                std::vector<double>({42, 0, 2, 0, 0, 3}), 6);
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(MeshNodeSelectionCoords)
     // selection of coordinate nodes
     {
         const auto& n = mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3));
-        BoostUnitTest::CheckEigenMatrix(n.GetValues(), Eigen::Vector2d(0, 3));
+        BoostUnitTest::CheckEigenMatrix(n.GetCoordinates(), Eigen::Vector2d(0, 3));
         BOOST_CHECK_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3.00001)), NuTo::Exception);
         BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3.00001), 1e-4));
     }

--- a/test/mechanics/mesh/MeshFem.cpp
+++ b/test/mechanics/mesh/MeshFem.cpp
@@ -60,10 +60,10 @@ BOOST_AUTO_TEST_CASE(MeshNodeSelectionCoords)
 
     // selection of coordinate nodes
     {
-        const auto& n = mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3));
+        const auto& n = geoMesh.NodeAtCoordinate(Eigen::Vector2d(0, 3));
         BoostUnitTest::CheckEigenMatrix(n.GetCoordinates(), Eigen::Vector2d(0, 3));
-        BOOST_CHECK_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3.00001)), NuTo::Exception);
-        BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 3.00001), 1e-4));
+        BOOST_CHECK_THROW(geoMesh.NodeAtCoordinate(Eigen::Vector2d(0, 3.00001)), NuTo::Exception);
+        BOOST_CHECK_NO_THROW(geoMesh.NodeAtCoordinate(Eigen::Vector2d(0, 3.00001), 1e-4));
     }
 
 
@@ -95,15 +95,15 @@ BOOST_AUTO_TEST_CASE(MeshNodeSelectionAxis)
         BOOST_CHECK(group1.Empty());
     }
     {
-        auto& nd0 = mesh.NodeAtCoordinate(Eigen::Vector2d(1, 0));
-        auto& nd1 = mesh.NodeAtCoordinate(Eigen::Vector2d(2, 0));
+        auto& nd0 = geoMesh.NodeAtCoordinate(Eigen::Vector2d(1, 0));
+        auto& nd1 = geoMesh.NodeAtCoordinate(Eigen::Vector2d(2, 0));
 
-        auto group0 = mesh.NodesAtAxis(NuTo::eDirection::Y);
+        auto group0 = geoMesh.NodesAtAxis(NuTo::eDirection::Y);
         BOOST_CHECK_EQUAL(group0.Size(), 2);
         BOOST_CHECK(group0.Contains(nd0));
         BOOST_CHECK(group0.Contains(nd1));
 
-        auto group1 = mesh.NodesAtAxis(NuTo::eDirection::Y, 2.);
+        auto group1 = geoMesh.NodesAtAxis(NuTo::eDirection::Y, 2.);
         BOOST_CHECK(group1.Empty());
     }
 }

--- a/test/mechanics/mesh/MeshFem.cpp
+++ b/test/mechanics/mesh/MeshFem.cpp
@@ -1,5 +1,6 @@
 #include "BoostUnitTest.h"
 #include "nuto/mechanics/mesh/MeshFem.h"
+#include "nuto/mechanics/mesh/GeometryMeshFem.h"
 #include "nuto/mechanics/mesh/MeshFemDofConvert.h"
 #include "nuto/mechanics/interpolation/InterpolationTrussLinear.h"
 #include "nuto/mechanics/interpolation/InterpolationTriangleLinear.h"
@@ -13,7 +14,8 @@ void SetStuff(NuTo::MeshFem& m)
 
 NuTo::MeshFem DummyMesh(NuTo::DofType dofType)
 {
-    NuTo::MeshFem mesh;
+    NuTo::GeometryMeshFem geoMesh;
+    NuTo::MeshFem mesh(geoMesh);
     auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
 
     auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d({1, 0}));
@@ -131,7 +133,8 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
      * |    \|
      * 0-----1
      */
-    NuTo::MeshFem mesh;
+    NuTo::GeometryMeshFem geoMesh;
+    NuTo::MeshFem mesh(geoMesh);
     auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
     auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
     auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
@@ -190,7 +193,8 @@ BOOST_AUTO_TEST_CASE(MeshConvertFromCoordinates)
      * |    \|     |
      * 0-----1-----4
      */
-    NuTo::MeshFem mesh;
+    NuTo::GeometryMeshFem geoMesh;
+    NuTo::MeshFem mesh(geoMesh);
     auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
     auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
     auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
@@ -220,7 +224,8 @@ BOOST_AUTO_TEST_CASE(MeshConvertFromCoordinates)
 
 BOOST_AUTO_TEST_CASE(MeshNodesTotalDof)
 {
-    NuTo::MeshFem mesh;
+    NuTo::GeometryMeshFem geoMesh;
+    NuTo::MeshFem mesh(geoMesh);
     auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
     auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
     auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
@@ -247,7 +252,8 @@ BOOST_AUTO_TEST_CASE(MeshNodesTotalDof)
 
 BOOST_AUTO_TEST_CASE(PartialAddDofConvert)
 {
-    NuTo::MeshFem mesh;
+    NuTo::GeometryMeshFem geoMesh;
+    NuTo::MeshFem mesh(geoMesh);
     auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
     auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
     auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));

--- a/test/mechanics/mesh/MeshFem.cpp
+++ b/test/mechanics/mesh/MeshFem.cpp
@@ -16,9 +16,9 @@ NuTo::MeshFem DummyMesh(NuTo::DofType dofType)
     NuTo::MeshFem mesh;
     auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
 
-    auto& n0 = mesh.Nodes.Add(Eigen::Vector2d({1, 0}));
-    auto& n1 = mesh.Nodes.Add(Eigen::Vector2d({2, 0}));
-    auto& n2 = mesh.Nodes.Add(Eigen::Vector2d({0, 3}));
+    auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d({1, 0}));
+    auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d({2, 0}));
+    auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d({0, 3}));
 
     auto& nd0 = mesh.Nodes.Add(42);
     auto& nd1 = mesh.Nodes.Add(4);
@@ -54,11 +54,11 @@ BOOST_AUTO_TEST_CASE(MeshAddStuff)
     auto& e0 = mesh.Elements[0];
     BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({1, 0, 2, 0, 0, 3}), 6);
 
-    mesh.Nodes[0].SetValue(0, 4);
+    mesh.CoordinateNodes[0].SetValue(0, 4);
     BoostUnitTest::CheckVector(e0.CoordinateElement().ExtractNodeValues(), std::vector<double>({4, 0, 2, 0, 0, 3}), 6);
 
     NuTo::MeshFem meshMoved = std::move(mesh);
-    meshMoved.Nodes[0].SetValue(0, 42);
+    meshMoved.CoordinateNodes[0].SetValue(0, 42);
     auto& e0FromMove = meshMoved.Elements[0];
     BoostUnitTest::CheckVector(e0FromMove.CoordinateElement().ExtractNodeValues(),
                                std::vector<double>({42, 0, 2, 0, 0, 3}), 6);
@@ -132,17 +132,17 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
      * 0-----1
      */
     NuTo::MeshFem mesh;
-    auto& n0 = mesh.Nodes.Add(Eigen::Vector2d(0, 0));
-    auto& n1 = mesh.Nodes.Add(Eigen::Vector2d(1, 0));
-    auto& n2 = mesh.Nodes.Add(Eigen::Vector2d(0, 1));
-    auto& n3 = mesh.Nodes.Add(Eigen::Vector2d(1, 1));
+    auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
+    auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
+    auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
+    auto& n3 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 1));
 
     auto& interpolation = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
     mesh.Elements.Add({{{n0, n1, n2}, interpolation}});
     mesh.Elements.Add({{{n1, n3, n2}, interpolation}});
 
     int expectedNumCoordinateNodes = 4;
-    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumCoordinateNodes);
+    BOOST_CHECK_EQUAL(mesh.CoordinateNodes.Size(), expectedNumCoordinateNodes);
 
 
     // add linear dof type
@@ -152,7 +152,8 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
 
     int expectedNumDof0Nodes = expectedNumCoordinateNodes; // same interpolation
 
-    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumCoordinateNodes + expectedNumDof0Nodes);
+    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumDof0Nodes);
+    BOOST_CHECK_EQUAL(mesh.CoordinateNodes.Size(), expectedNumCoordinateNodes);
     BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 0), dof0));
 
 
@@ -173,7 +174,7 @@ BOOST_AUTO_TEST_CASE(MeshConvert)
     NuTo::AddDofInterpolation(&mesh, dof1, interpolationQuadratic);
 
     int expectedNumDof1Nodes = 9;
-    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumCoordinateNodes + expectedNumDof0Nodes + expectedNumDof1Nodes);
+    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumDof0Nodes + expectedNumDof1Nodes);
 }
 
 BOOST_AUTO_TEST_CASE(MeshConvertFromCoordinates)
@@ -190,12 +191,12 @@ BOOST_AUTO_TEST_CASE(MeshConvertFromCoordinates)
      * 0-----1-----4
      */
     NuTo::MeshFem mesh;
-    auto& n0 = mesh.Nodes.Add(Eigen::Vector2d(0, 0));
-    auto& n1 = mesh.Nodes.Add(Eigen::Vector2d(1, 0));
-    auto& n2 = mesh.Nodes.Add(Eigen::Vector2d(0, 1));
-    auto& n3 = mesh.Nodes.Add(Eigen::Vector2d(1, 1));
-    auto& n4 = mesh.Nodes.Add(Eigen::Vector2d(2, 0));
-    auto& n5 = mesh.Nodes.Add(Eigen::Vector2d(2, 1));
+    auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
+    auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
+    auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
+    auto& n3 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 1));
+    auto& n4 = mesh.CoordinateNodes.Add(Eigen::Vector2d(2, 0));
+    auto& n5 = mesh.CoordinateNodes.Add(Eigen::Vector2d(2, 1));
 
     auto& interpolationTriangle = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
     auto& interpolationQuad = mesh.CreateInterpolation(NuTo::InterpolationQuadLinear());
@@ -203,7 +204,7 @@ BOOST_AUTO_TEST_CASE(MeshConvertFromCoordinates)
     mesh.Elements.Add({{{n1, n4, n5, n3}, interpolationQuad}});
 
     int expectedNumCoordinateNodes = 6;
-    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumCoordinateNodes);
+    BOOST_CHECK_EQUAL(mesh.CoordinateNodes.Size(), expectedNumCoordinateNodes);
 
 
     // add linear dof type
@@ -213,16 +214,16 @@ BOOST_AUTO_TEST_CASE(MeshConvertFromCoordinates)
 
     int expectedNumDof0Nodes = expectedNumCoordinateNodes; // same interpolation
 
-    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumCoordinateNodes + expectedNumDof0Nodes);
+    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), expectedNumDof0Nodes);
     BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0, 0), dof0));
 }
 
 BOOST_AUTO_TEST_CASE(MeshNodesTotalDof)
 {
     NuTo::MeshFem mesh;
-    auto& n0 = mesh.Nodes.Add(Eigen::Vector2d(0, 0));
-    auto& n1 = mesh.Nodes.Add(Eigen::Vector2d(1, 0));
-    auto& n2 = mesh.Nodes.Add(Eigen::Vector2d(0, 1));
+    auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
+    auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
+    auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
 
     auto& interpolationTriangle = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
     auto& interpolationTruss = mesh.CreateInterpolation(NuTo::InterpolationTrussLinear());
@@ -247,9 +248,9 @@ BOOST_AUTO_TEST_CASE(MeshNodesTotalDof)
 BOOST_AUTO_TEST_CASE(PartialAddDofConvert)
 {
     NuTo::MeshFem mesh;
-    auto& n0 = mesh.Nodes.Add(Eigen::Vector2d(0, 0));
-    auto& n1 = mesh.Nodes.Add(Eigen::Vector2d(1, 0));
-    auto& n2 = mesh.Nodes.Add(Eigen::Vector2d(0, 1));
+    auto& n0 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 0));
+    auto& n1 = mesh.CoordinateNodes.Add(Eigen::Vector2d(1, 0));
+    auto& n2 = mesh.CoordinateNodes.Add(Eigen::Vector2d(0, 1));
 
     auto& interpolationTriangle = mesh.CreateInterpolation(NuTo::InterpolationTriangleLinear());
     auto& interpolationTruss = mesh.CreateInterpolation(NuTo::InterpolationTrussLinear());

--- a/test/mechanics/mesh/MeshGmsh.cpp
+++ b/test/mechanics/mesh/MeshGmsh.cpp
@@ -26,7 +26,7 @@ void CheckMesh(std::string meshFile, int numNodesExpected)
     MeshGmsh m(meshFile);
     auto& meshFem = m.GetMeshFEM();
     BOOST_CHECK_EQUAL(meshFem.Nodes.Size(), numNodesExpected);
-    const ElementFem& element = meshFem.Elements.begin()->CoordinateElement();
+    const DofElementFem& element = meshFem.Elements.begin()->CoordinateElement();
     const auto& interpolation = element.Interpolation();
     BOOST_CHECK_EQUAL(interpolation.GetNumNodes(), numNodesExpected);
 

--- a/test/mechanics/mesh/MeshGmsh.cpp
+++ b/test/mechanics/mesh/MeshGmsh.cpp
@@ -35,7 +35,7 @@ void CheckMesh(std::string meshFile, int numNodesExpected)
     for (int iNode = 0; iNode < interpolation.GetNumNodes(); ++iNode)
     {
         auto coord = interpolation.GetLocalCoords(iNode);
-        Jacobian j(element.ExtractNodeValues(), interpolation.GetDerivativeShapeFunctions(coord));
+        Jacobian j(element.ExtractCoordinates(), interpolation.GetDerivativeShapeFunctions(coord));
         bool isPositiveForINode = j.Det() > -1.e-10;
         if (iNode == 0)
             isPositive = isPositiveForINode;

--- a/test/mechanics/mesh/MeshGmsh.cpp
+++ b/test/mechanics/mesh/MeshGmsh.cpp
@@ -25,8 +25,8 @@ void CheckMesh(std::string meshFile, int numNodesExpected)
     BOOST_CHECK_NO_THROW(MeshGmsh{meshFile});
     MeshGmsh m(meshFile);
     auto& meshFem = m.GetMeshFEM();
-    BOOST_CHECK_EQUAL(meshFem.Nodes.Size(), numNodesExpected);
-    const DofElementFem& element = meshFem.Elements.begin()->CoordinateElement();
+    BOOST_CHECK_EQUAL(meshFem.CoordinateNodes.Size(), numNodesExpected);
+    const CoordinateElementFem& element = meshFem.Elements.begin()->CoordinateElement();
     const auto& interpolation = element.Interpolation();
     BOOST_CHECK_EQUAL(interpolation.GetNumNodes(), numNodesExpected);
 
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(BinaryImport)
 {
     MeshGmsh m("meshes/binary.msh");
     auto& meshFem = m.GetMeshFEM();
-    BOOST_CHECK_EQUAL(meshFem.Nodes.Size(), 8);
+    BOOST_CHECK_EQUAL(meshFem.CoordinateNodes.Size(), 8);
     BOOST_CHECK_EQUAL(meshFem.Elements.Size(), 7);
     BOOST_CHECK_EQUAL(meshFem.Elements.begin()->CoordinateElement().Interpolation().GetNumNodes(), 3);
 }

--- a/test/mechanics/mesh/MeshGmsh.cpp
+++ b/test/mechanics/mesh/MeshGmsh.cpp
@@ -26,7 +26,7 @@ void CheckMesh(std::string meshFile, int numNodesExpected)
     MeshGmsh m(meshFile);
     auto& meshFem = m.GetMeshFEM();
     BOOST_CHECK_EQUAL(meshFem.CoordinateNodes.Size(), numNodesExpected);
-    const CoordinateElementFem& element = meshFem.Elements.begin()->CoordinateElement();
+    const CoordinateElementFem& element = *meshFem.Elements.begin();
     const auto& interpolation = element.Interpolation();
     BOOST_CHECK_EQUAL(interpolation.GetNumNodes(), numNodesExpected);
 
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(BinaryImport)
     auto& meshFem = m.GetMeshFEM();
     BOOST_CHECK_EQUAL(meshFem.CoordinateNodes.Size(), 8);
     BOOST_CHECK_EQUAL(meshFem.Elements.Size(), 7);
-    BOOST_CHECK_EQUAL(meshFem.Elements.begin()->CoordinateElement().Interpolation().GetNumNodes(), 3);
+    BOOST_CHECK_EQUAL(meshFem.Elements.begin()->Interpolation().GetNumNodes(), 3);
 }
 
 BOOST_AUTO_TEST_CASE(QuadLinear)

--- a/test/mechanics/mesh/UnitMeshFem.cpp
+++ b/test/mechanics/mesh/UnitMeshFem.cpp
@@ -4,7 +4,7 @@
 
 void CheckJacobians(NuTo::MeshFem& mesh)
 {
-    int dim = mesh.Elements[0].CoordinateElement().GetNode(0).GetValues().rows();
+    int dim = mesh.Elements[0].CoordinateElement().GetNode(0).GetCoordinates().rows();
     Eigen::VectorXd ip = Eigen::VectorXd::Zero(dim);
     for (auto& element : mesh.Elements)
     {
@@ -62,8 +62,8 @@ BOOST_AUTO_TEST_CASE(MeshTrusses)
 
     for (const auto& element : mesh.Elements)
     {
-        BOOST_CHECK_LT(element.CoordinateElement().GetNode(0).GetValues()[0],
-                       element.CoordinateElement().GetNode(1).GetValues()[0]);
+        BOOST_CHECK_LT(element.CoordinateElement().GetNode(0).GetCoordinates()[0],
+                       element.CoordinateElement().GetNode(1).GetCoordinates()[0]);
     }
 }
 
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(MeshValidAfterTransform)
     expected << 0, 0, 4, 0, 4, 42, 0, 42;
     BoostUnitTest::CheckEigenMatrix(transformedCoordinateElement.ExtractNodeValues(), expected);
 
-    transformedMesh.CoordinateNodes[0].SetValue(0, 6174);
+    transformedMesh.CoordinateNodes[0].SetCoordinate(0, 6174);
     expected << 6174, 0, 4, 0, 4, 42, 0, 42;
     BoostUnitTest::CheckEigenMatrix(transformedCoordinateElement.ExtractNodeValues(), expected);
 }

--- a/test/mechanics/mesh/UnitMeshFem.cpp
+++ b/test/mechanics/mesh/UnitMeshFem.cpp
@@ -10,7 +10,7 @@ void CheckJacobians(NuTo::GeometryMeshFem& mesh)
     for (auto& element : mesh.Elements)
     {
         auto d_dxi = element.GetDerivativeShapeFunctions(ip);
-        auto x = element.ExtractNodeValues();
+        auto x = element.ExtractCoordinates();
         auto J = NuTo::Jacobian(x, d_dxi);
         BOOST_CHECK_GT(J.Det(), 0.);
     }
@@ -98,18 +98,18 @@ BOOST_AUTO_TEST_CASE(MeshValidAfterTransform)
     expected << 0, 0, 1, 0, 1, 1, 0, 1;
 
     auto& coordinateElement = mesh.Elements[0];
-    BoostUnitTest::CheckEigenMatrix(coordinateElement.ExtractNodeValues(), expected);
+    BoostUnitTest::CheckEigenMatrix(coordinateElement.ExtractCoordinates(), expected);
 
     auto f = [](Eigen::VectorXd coords) { return Eigen::Vector2d(coords[0] * 4, coords[1] * 42); };
 
     NuTo::GeometryMeshFem transformedMesh = NuTo::UnitMeshFem::Transform(std::move(mesh), f);
     auto& transformedCoordinateElement = transformedMesh.Elements[0];
     expected << 0, 0, 4, 0, 4, 42, 0, 42;
-    BoostUnitTest::CheckEigenMatrix(transformedCoordinateElement.ExtractNodeValues(), expected);
+    BoostUnitTest::CheckEigenMatrix(transformedCoordinateElement.ExtractCoordinates(), expected);
 
     transformedMesh.CoordinateNodes[0].SetCoordinate(0, 6174);
     expected << 6174, 0, 4, 0, 4, 42, 0, 42;
-    BoostUnitTest::CheckEigenMatrix(transformedCoordinateElement.ExtractNodeValues(), expected);
+    BoostUnitTest::CheckEigenMatrix(transformedCoordinateElement.ExtractCoordinates(), expected);
 }
 
 // This test is related to our github issue #148. Visit github to read about the details

--- a/test/mechanics/mesh/UnitMeshFem.cpp
+++ b/test/mechanics/mesh/UnitMeshFem.cpp
@@ -11,7 +11,7 @@ void CheckJacobians(NuTo::GeometryMeshFem& mesh)
     {
         auto d_dxi = element.GetDerivativeShapeFunctions(ip);
         auto x = element.ExtractNodeValues();
-        auto J = NuTo::Jacobian(x, d_dxi, dim);
+        auto J = NuTo::Jacobian(x, d_dxi);
         BOOST_CHECK_GT(J.Det(), 0.);
     }
 }

--- a/test/mechanics/mesh/UnitMeshFem.cpp
+++ b/test/mechanics/mesh/UnitMeshFem.cpp
@@ -17,7 +17,7 @@ void CheckJacobians(NuTo::MeshFem& mesh)
 
 void Check2DMesh(NuTo::MeshFem& mesh)
 {
-    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), 3 * 8);
+    BOOST_CHECK_EQUAL(mesh.CoordinateNodes.Size(), 3 * 8);
 
     BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(0., 0.)));
     BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector2d(1., 1.)));
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(MeshTrusses)
     constexpr int numElements = 15;
     auto mesh = NuTo::UnitMeshFem::CreateLines(numElements);
     BOOST_CHECK_EQUAL(mesh.Elements.Size(), numElements);
-    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), numElements + 1);
+    BOOST_CHECK_EQUAL(mesh.CoordinateNodes.Size(), numElements + 1);
 
     auto IsWholeNumber = [](double d, double eps = 1.e-12) { return std::abs(d - std::floor(d)) < eps; };
 
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(MeshBrick)
 {
     auto mesh = NuTo::UnitMeshFem::CreateBricks(2, 7, 3);
     BOOST_CHECK_EQUAL(mesh.Elements.Size(), 2 * 7 * 3);
-    BOOST_CHECK_EQUAL(mesh.Nodes.Size(), 3 * 8 * 4);
+    BOOST_CHECK_EQUAL(mesh.CoordinateNodes.Size(), 3 * 8 * 4);
     BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector3d(0, 0, 0)));
     BOOST_CHECK_NO_THROW(mesh.NodeAtCoordinate(Eigen::Vector3d(1, 1, 1)));
     CheckJacobians(mesh);
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(MeshValidAfterTransform)
     expected << 0, 0, 4, 0, 4, 42, 0, 42;
     BoostUnitTest::CheckEigenMatrix(transformedCoordinateElement.ExtractNodeValues(), expected);
 
-    transformedMesh.Nodes[0].SetValue(0, 6174);
+    transformedMesh.CoordinateNodes[0].SetValue(0, 6174);
     expected << 6174, 0, 4, 0, 4, 42, 0, 42;
     BoostUnitTest::CheckEigenMatrix(transformedCoordinateElement.ExtractNodeValues(), expected);
 }

--- a/test/mechanics/nodes/NodeSimple.cpp
+++ b/test/mechanics/nodes/NodeSimple.cpp
@@ -1,17 +1,17 @@
 #include "BoostUnitTest.h"
 #include "TypeTraits.h"
-#include "nuto/mechanics/nodes/NodeSimple.h"
+#include "nuto/mechanics/nodes/DofNode.h"
 
 
-BOOST_AUTO_TEST_CASE(NodeSimpleCopyMove)
+BOOST_AUTO_TEST_CASE(DofNodeCopyMove)
 {
-    NuTo::Test::Copy<NuTo::NodeSimple>();
-    NuTo::Test::Move<NuTo::NodeSimple>();
+    NuTo::Test::Copy<NuTo::DofNode>();
+    NuTo::Test::Move<NuTo::DofNode>();
 }
 
-BOOST_AUTO_TEST_CASE(NodeSimpleValues)
+BOOST_AUTO_TEST_CASE(DofNodeValues)
 {
-    NuTo::NodeSimple node(Eigen::Vector2d{1., 2.});
+    NuTo::DofNode node(Eigen::Vector2d{1., 2.});
     BOOST_CHECK_EQUAL(node.GetNumValues(), 2);
 
     BoostUnitTest::CheckVector(node.GetValues(), std::vector<double>({1., 2.}), 2);
@@ -21,18 +21,18 @@ BOOST_AUTO_TEST_CASE(NodeSimpleValues)
     BoostUnitTest::CheckVector(node.GetValues(), std::vector<double>({11., 12.}), 2);
 }
 
-BOOST_AUTO_TEST_CASE(NodeSimpleDofNumbers)
+BOOST_AUTO_TEST_CASE(DofNodeDofNumbers)
 {
-    NuTo::NodeSimple node(Eigen::Vector3d{1., 2., 3.});
+    NuTo::DofNode node(Eigen::Vector3d{1., 2., 3.});
     BOOST_CHECK_EQUAL(node.GetDofNumber(0), -1);
 
     node.SetDofNumber(1, 42);
     BOOST_CHECK_EQUAL(node.GetDofNumber(1), 42);
 }
 
-BOOST_AUTO_TEST_CASE(NodeSimpleInstances)
+BOOST_AUTO_TEST_CASE(DofNodeInstances)
 {
-    NuTo::NodeSimple node(3, 2);
+    NuTo::DofNode node(3, 2);
     BOOST_CHECK_EQUAL(node.GetNumInstances(), 2);
 
     node.AllocateInstances(1);


### PR DESCRIPTION
Moves coordinate related functionality from MeshFem to the newly created GeometryMeshFem #263 .
To construct a MeshFem you always need a GeometryMeshFem.

Is a preparation for the introduction of an interpolation space.