### PR TITLE
Fix minor problem in quasistatic solver

### DIFF
--- a/nuto/mechanics/tools/QuasistaticSolver.cpp
+++ b/nuto/mechanics/tools/QuasistaticSolver.cpp
@@ -52,7 +52,7 @@ DofVector<double> QuasistaticSolver::TrialState(double newGlobalTime, const Cons
 {
     // compute hessian for last converged time step
     auto hessian0 = mProblem.Hessian0(mX, mDofs, mGlobalTime, mTimeStep);
-    Eigen::MatrixXd hessian0Eigen(ToEigen(hessian0, mDofs));
+    Eigen::SparseMatrix<double> hessian0Eigen(ToEigen(hessian0, mDofs));
 
     // update time step
     double newTimeStep = newGlobalTime - mGlobalTime;


### PR DESCRIPTION
The trial state calculation used a` Eigen::MatrixXd` to store the Hessian which caused larger problems to crash with `bad_alloc`. I changed the type to `Eigen::SparseMatrix<double>`.