### PR TITLE
Change Doxygen source directory to `nuto/`

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = . ../src ../applications
+INPUT                  = . ../nuto ../applications
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
This is a change that is left over from the `src/`->`nuto/` transition #222 and causes the documentation to be incomplete.