### PR TITLE
Add functionality to groups

### DIFF
--- a/nuto/base/Group.h
+++ b/nuto/base/Group.h
@@ -139,6 +139,13 @@ Group<T> Unite(const Group<T>& one, const Group<T>& two)
     return newGroup;
 }
 
+//! @brief Unite multiple groups
+template <typename T, typename... TArgs>
+Group<T> Unite(const Group<T>& one, const TArgs&... args)
+{
+    return Unite(one, Unite(args...));
+}
+
 //! @brief Returns group with elements of group one that are not in group two
 template <typename T>
 Group<T> Difference(const Group<T>& one, const Group<T>& two)
@@ -160,6 +167,7 @@ Group<T> Intersection(const Group<T>& one, const Group<T>& two)
             newGroup.Add(t);
     return newGroup;
 }
+
 
 //! @brief Returns group with elements that are only in one group not in both
 template <typename T>

--- a/nuto/base/Group.h
+++ b/nuto/base/Group.h
@@ -70,6 +70,16 @@ public:
             Add(element);
     }
 
+    T& operator[](size_t index)
+    {
+        return *mData[index];
+    }
+
+    const T& operator[](size_t index) const
+    {
+        return *mData[index];
+    }
+
     //! @brief Add element to group
     //! @param element single element to add
     void Add(T& element)

--- a/test/base/Group.cpp
+++ b/test/base/Group.cpp
@@ -54,53 +54,45 @@ struct GroupTestFixture
     Group<Foo> groupTwo;
 };
 
+
+BOOST_FIXTURE_TEST_CASE(directAccessOperator, GroupTestFixture)
+{
+    std::vector<Foo*> expectedOne = {&a, &b, &c};
+    for (unsigned int i = 0; i < groupOne.Size(); ++i)
+        BOOST_CHECK(groupOne[i] == *expectedOne[i]);
+
+    std::vector<Foo*> expectedTwo = {&e, &d, &c};
+    for (unsigned int i = 0; i < groupTwo.Size(); ++i)
+        BOOST_CHECK(groupTwo[i] == *expectedTwo[i]);
+}
+
 BOOST_FIXTURE_TEST_CASE(unionTest, GroupTestFixture)
 {
     auto unionGroup = Unite(groupOne, groupTwo);
     BOOST_CHECK_EQUAL(unionGroup.Size(), 5);
-    auto it = unionGroup.begin();
-    BOOST_CHECK(*it == a);
 
-    std::advance(it, 1);
-    BOOST_CHECK(*it == b);
-
-    std::advance(it, 1);
-    BOOST_CHECK(*it == c);
-
-    std::advance(it, 1);
-    BOOST_CHECK(*it == e);
-
-    std::advance(it, 1);
-    BOOST_CHECK(*it == d);
+    std::vector<Foo*> expected = {&a, &b, &c, &e, &d};
+    for (unsigned int i = 0; i < unionGroup.Size(); ++i)
+        BOOST_CHECK(unionGroup[i] == *expected[i]);
 }
 
 BOOST_FIXTURE_TEST_CASE(multipleGroupsUnionTest, GroupTestFixture)
 {
-    Group<Foo> groups[5];
-    groups[0].Add(c);
-    groups[1].Add(e);
-    groups[2].Add(e);
-    groups[2].Add(d);
-    groups[3].Add(a);
-    groups[3].Add(e);
-    groups[4].Add(b);
+    Group<Foo> group1, group2, group3, group4, group5;
+    group1.Add(c);
+    group2.Add(e);
+    group3.Add(e);
+    group3.Add(d);
+    group4.Add(a);
+    group4.Add(e);
+    group5.Add(b);
 
-    auto unionGroup = Unite(groups[0], groups[1], groups[2], groups[3], groups[4]);
+    auto unionGroup = Unite(group1, group2, group3, group4, group5);
     BOOST_CHECK_EQUAL(unionGroup.Size(), 5);
-    auto it = unionGroup.begin();
-    BOOST_CHECK(*it == c);
 
-    std::advance(it, 1);
-    BOOST_CHECK(*it == e);
-
-    std::advance(it, 1);
-    BOOST_CHECK(*it == d);
-
-    std::advance(it, 1);
-    BOOST_CHECK(*it == a);
-
-    std::advance(it, 1);
-    BOOST_CHECK(*it == b);
+    std::vector<Foo*> expected = {&c, &e, &d, &a, &b};
+    for (unsigned int i = 0; i < unionGroup.Size(); ++i)
+        BOOST_CHECK(unionGroup[i] == *expected[i]);
 }
 
 

--- a/test/base/Group.cpp
+++ b/test/base/Group.cpp
@@ -74,6 +74,35 @@ BOOST_FIXTURE_TEST_CASE(unionTest, GroupTestFixture)
     BOOST_CHECK(*it == d);
 }
 
+BOOST_FIXTURE_TEST_CASE(multipleGroupsUnionTest, GroupTestFixture)
+{
+    Group<Foo> groups[5];
+    groups[0].Add(c);
+    groups[1].Add(e);
+    groups[2].Add(e);
+    groups[2].Add(d);
+    groups[3].Add(a);
+    groups[3].Add(e);
+    groups[4].Add(b);
+
+    auto unionGroup = Unite(groups[0], groups[1], groups[2], groups[3], groups[4]);
+    BOOST_CHECK_EQUAL(unionGroup.Size(), 5);
+    auto it = unionGroup.begin();
+    BOOST_CHECK(*it == c);
+
+    std::advance(it, 1);
+    BOOST_CHECK(*it == e);
+
+    std::advance(it, 1);
+    BOOST_CHECK(*it == d);
+
+    std::advance(it, 1);
+    BOOST_CHECK(*it == a);
+
+    std::advance(it, 1);
+    BOOST_CHECK(*it == b);
+}
+
 
 BOOST_FIXTURE_TEST_CASE(differenceTest, GroupTestFixture)
 {


### PR DESCRIPTION
I added a variadic template function that unites more than two groups. So instead of writing something like:

~~~cpp
auto unitedGroup = Unite(group1, Unite(Unite(group2, group3), Unite(group4, group5));
~~~

you can now write:

~~~cpp
auto unitedGroup = Unite(group1, group2, group3, group4, group5);
~~~

This works for an arbitrary number of groups. Test is also included.